### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Every author of an accepted contribution will receive a *free digital copy of th
 
 #### Trusted Contributors
 
-The following users are trusted contributors (push access) that have proven themselves through excellent judgement and outstanding contributions to the book. We support and strongely encourage these users to make corrections and improvements to the book at will (recipes aside.)
+The following users are trusted contributors (push access) that have proven themselves through excellent judgement and outstanding contributions to the book. We support and strongly encourage these users to make corrections and improvements to the book at will (recipes aside.)
 
 * @jcromartie
 

--- a/basics/interactive-docs/interactive-docs.asciidoc
+++ b/basics/interactive-docs/interactive-docs.asciidoc
@@ -101,6 +101,6 @@ clojure.core/+
 ----
 
 Exploring Clojure in this way is a great way to learn about core
-functions and advanced Clojure programming techinques. The
+functions and advanced Clojure programming techniques. The
 +clojure.core+ namespace is chock full of high-quality and
 high-performance code at your fingertips.

--- a/build-atlas.sh
+++ b/build-atlas.sh
@@ -8,6 +8,6 @@ lein run ../clojure-cookbook.asciidoc /tmp/clojure-cookbook-atlas
 cd /tmp/clojure-cookbook-atlas
 
 git add .
-git commit -m "autmated update from github repository"
+git commit -m "automated update from github repository"
 git push
 

--- a/composite-data/maps/multiple-values/src/clojure_cookbook/multiple_values.clj
+++ b/composite-data/maps/multiple-values/src/clojure_cookbook/multiple_values.clj
@@ -4,7 +4,7 @@
   "An associative structure that can contain multiple values for a key"
   (insert [m key value] "Insert a value into a MultiAssociative")
   (delete [m key value] "Remove a value from a MultiAssociative")
-  (get-all [m key] "Returns a set of all values storted at key in a
+  (get-all [m key] "Returns a set of all values stored at key in a
                     MultiAssociative. Returns the empty set if there
                     are no values."))
 
@@ -15,7 +15,7 @@
   (and (set? v) (::multi-value (meta v))))
 
 (defn value-set
-  "Given any number of items as argumnents, returns a set representing
+  "Given any number of items as arguments, returns a set representing
   multiple values in a MultiAssociative. If there is only one item,
   simply returns the item"
   [& items]

--- a/databases/database-up-n-running/database-up-n-running.asciidoc
+++ b/databases/database-up-n-running/database-up-n-running.asciidoc
@@ -46,7 +46,7 @@ Add
 
 to your dependencies to install the main library to access the database.
 
-You also need to installl the specific drivers for your type of database[1], in our case we need to add the SQLite drivers.
+You also need to install the specific drivers for your type of database[1], in our case we need to add the SQLite drivers.
 
 [source, clojure]
 ----
@@ -93,7 +93,7 @@ Now you can execute query against the database, to make sure that everything wor
 
 ===== Discussion
 
-In this recipe we used SQLite but it is definitely possible to use differents SQL engines, such as PostgreSQL or MySQL or others.
+In this recipe we used SQLite but it is definitely possible to use different SQL engines, such as PostgreSQL or MySQL or others.
 SQLite is very friendly and easy to set up it doesn't even ask for a username and password, while other databases do, in order to deal with those you need to add your username and password at the connection map.
 
 Obviously is also possible to connect to remote databases, you need to indicate the URI in the :subname of the connection.

--- a/deployment/deploy-on-lein/deploy-on-lein.asciidoc
+++ b/deployment/deploy-on-lein/deploy-on-lein.asciidoc
@@ -17,7 +17,7 @@ See http://github.com/clojure-cookbook/clojure-cookbook/issues/90
 ==== Push library on Clojars
 
 ===== Problem
-After that you build your own library in clojure you want to make it public so that everybody can use it and simply add it to their dependecies.
+After that you build your own library in clojure you want to make it public so that everybody can use it and simply add it to their dependencies.
 
 ===== Solution
 

--- a/local-io/json/read-write-json/read-write-json.asciidoc
+++ b/local-io/json/read-write-json/read-write-json.asciidoc
@@ -80,7 +80,7 @@ Reading JSON with +read-str+ will not yield the same Clojure data that was writt
 ;; -> {:age 32, :name "Stefan"}
 ----
 
-It is common for JSON to be formated in lowerCamelCase. If so, you can use a key function that transforms lowerCamelCase to idiomatic Clojure format.
+It is common for JSON to be formatted in lowerCamelCase. If so, you can use a key function that transforms lowerCamelCase to idiomatic Clojure format.
 
 [source,clojure]
 ----


### PR DESCRIPTION
@rkneufeld contributing to ALL the projects ;)

I did notice "adault" was spelled wrong but didn't change it since it would effect the output.

The local whitelist, .lein-spell, for this project:

```
acos
alan
alice
anhinga
april
arizona
australia
bday
california
canadianize
ceil
cffe
coloured
dabase
dramatico
eadc
editline
eigenhombre
faux
feedparser
ffffffff
florida
freqs
fwhitespace
greatsword
greg
gregorian
hsqldb
jcromartie
judgement
jwhitlark
keygen
keyint
kilometres
l'ordinateur
linkification
locutus
luke
mary
nada
neighbour
neighbours
neufeld
nluke
nosuch
nput
nryan
osbert
phainopepla
picard
pprint
publics
rowid
ryan
ryans
simo
spitn
sqrt
subname
tableify
triml
trimr
vanderhart
vous
yyyy
zclj
```
