### PR TITLE
Fix title typo in current-date recipe

### DIFF
--- a/primitive-data/dates/current-date/current-date.asciidoc
+++ b/primitive-data/dates/current-date/current-date.asciidoc
@@ -1,4 +1,4 @@
-==== Obtaining the Current Data and Time
+==== Obtaining the Current Date and Time
 
 ===== Problem
 


### PR DESCRIPTION
Was titled Obtaining the Current Data and Time, where Data should have instead been Date
