### PR TITLE
fix AsciiDoc errors; add escaping where necessary

### DIFF
--- a/composite-data/sets/creating-a-set/creating-a-set.asciidoc
+++ b/composite-data/sets/creating-a-set/creating-a-set.asciidoc
@@ -52,7 +52,7 @@ Alternatively, use +into+ with a set to create a new set.
 
 [TIP]
 .Set Construction Performance
-********************************************************************************
+====
 At the time of writing, the +into+ technique is about three times
 faster than +set+ for large collections of objects. Use it whenever
 you're working with large sets where performance is a concern.
@@ -68,7 +68,7 @@ user=> (time (dotimes [_ 100] (into #{} largeseq)))
 "Elapsed time: 1329.66 msecs"
 nil
 ----
-********************************************************************************
+====
 
 Create a sorted set with +sorted-set+.
 

--- a/local-io/console/read-unbuffered-keystroke/read-unbuffered-keystroke.asciidoc
+++ b/local-io/console/read-unbuffered-keystroke/read-unbuffered-keystroke.asciidoc
@@ -11,7 +11,7 @@ single, unbuffered keystroke from the console.
 
 ===== Solution
 
-Use +ConsoleReader+ from the JLine footnote:[https://github.com/jline/jline2];
+Use +ConsoleReader+ from the JLine footnote:[https://github.com/jline/jline2]
 library, a Java library for handling console input.
 
 JLine is similar to BSD editline and GNU readline. There are a few

--- a/primitive-data/math/bitwise-operations/bitwise-operations.asciidoc
+++ b/primitive-data/math/bitwise-operations/bitwise-operations.asciidoc
@@ -7,7 +7,7 @@ You need to perform bitwise operations on numbers.
 ===== Solution
 
 Bitwise operations aren't quite as useful in Clojure as they are in
-systems languages like C or C++, but the techniques learned in those
+systems languages like C or C\++, but the techniques learned in those
 systems languages can still be useful. Clojure exposes a number of
 bitwise operations in its core namespace, all prefixed with +bit-+.
 

--- a/primitive-data/math/simple-statistics/simple-statistics.asciidoc
+++ b/primitive-data/math/simple-statistics/simple-statistics.asciidoc
@@ -124,9 +124,9 @@ Here is a break down of how +mode+ works:
 
 * <1> +frequencies+ returns a map that tallies the number of times
 each value in +coll+ occurs. This would be something like +{:a 1 :b 2}+
-* <2> +group-by+ with +second+ inverts the +freqs+ map, turning keys into values, merging duplicates into groups. This would turn +{:a 1 :b 1}+ into +{1 [[:a 1] [:b 1]]}+.
+* <2> +group-by+ with +second+ inverts the +freqs+ map, turning keys into values, merging duplicates into groups. This would turn +{:a 1 :b 1}+ into `{1 [[:a 1] [:b 1]]}`.
 * <3> The list of occurrences is now sortable; the last pair in the sorted list will be the modes, or most frequently occurring values.
-* <4> The final step is processing the raw mode pairs into discrete values. Taking +second+ turns +[2 [[:alan 2]]]+ into +[[:alan 2]]+, and +(map first)+ turns that into '(:alan).
+* <4> The final step is processing the raw mode pairs into discrete values. Taking +second+ turns `[2 [[:alan 2]]]` into `[[:alan 2]]`, and +(map first)+ turns that into +'(:alan)+.
 
 The standard deviation measures how much, on average, the individual values in a
 population deviate from the mean: The higher the standard deviation is, the

--- a/primitive-data/strings/concatenating-strings/concatenating-strings.asciidoc
+++ b/primitive-data/strings/concatenating-strings/concatenating-strings.asciidoc
@@ -48,7 +48,7 @@ the next. When provided +nil+ or invoked without arguments +str+ will
 return the identity value for strings, the empty string.
 
 When it comes to string concatenation Clojure takes a fairly hands-off
-approach. There is nothing string-specific about +(apply str ...)+, it
+approach. There is nothing string-specific about `(apply str ...)`, it
 is merely the higher-order function +apply+ being used to emulate
 calling +str+ with a variable number of arguments.
 

--- a/primitive-data/strings/introduction/introduction.asciidoc
+++ b/primitive-data/strings/introduction/introduction.asciidoc
@@ -18,7 +18,7 @@ find that small set of very string-specific functions in the
 +clojure.string+ namespace.
 
 We suggest you "require as" the +clojure.string+ namespace when you
-need it. Blindly +:use+ing a namespace is always annoying, and often
+need it. Blindly ++:use++ing a namespace is always annoying, and often
 results in collisions/confusion. Prefixing everything with
 +clojure.string+ is also right-out.
 

--- a/webapps/ring/cookies/cookies.asciidoc
+++ b/webapps/ring/cookies/cookies.asciidoc
@@ -82,7 +82,7 @@ You can add other optional parameters to each cookie, along with `:value`. From 
 https://github.com/ring-clojure/ring/wiki/Cookies[Ring Cookie Documentation]:
 
 [quote, Ring Docs]
-----
+____
 As well as setting the value of the cookie, you can also set additional attributes:
 
 * `:domain` - restrict the cookie to a specific domain
@@ -91,4 +91,4 @@ As well as setting the value of the cookie, you can also set additional attribut
 * `:http-only` - restrict the cookie to HTTP if true (not accessible via e.g. JavaScript)
 * `:max-age` - the number of seconds until the cookie expires
 * `:expires` - a specific date and time the cookie expires
-----
+____

--- a/webapps/ring/middleware/middleware.asciidoc
+++ b/webapps/ring/middleware/middleware.asciidoc
@@ -77,7 +77,7 @@ a number of middlewares to add to your app, including one called `params` that
 does the same as the middleware we just wrote but better:
 
 [quote, Ring Documentation]
-----
+____
 **wrap-params**
 
 Middleware to parse urlencoded parameters from the query string and form
@@ -90,7 +90,7 @@ Takes an optional configuration map. Recognized keys are:
   :encoding - encoding to use for url-decoding. If not specified, uses
               the request character encoding, or "UTF-8" if no request
               character encoding is set.
-----
+____
 
 You are in no way limited to using one middleware.  Usually, you'll at
 least want to use the cookie, session, and params middleware.  One concise way to wrap your handler

--- a/webapps/webapps.asciidoc
+++ b/webapps/webapps.asciidoc
@@ -19,4 +19,4 @@ include::ring/compojure/compojure.asciidoc[]
 
 include::liberator/basic.asciidoc[]
 
-include::templatating-with-selmer/templating-with-selmer.asciidoc[]
+include::templating-with-selmer/templating-with-selmer.asciidoc[]


### PR DESCRIPTION
- use correct delimiter for quote blocks (____ instead of ----)
- use example block delimiters instead of sidebar delimiters for admonition block
- add backslash in front of + in C++
- use backticks to escape inline clojure snippets where necessary
- fix path to templating-with-selmer.asciidoc include file
