### PR TITLE
Update clojure-cookbook.asciidoc to include 'basics' subdirectory

### DIFF
--- a/clojure-cookbook.asciidoc
+++ b/clojure-cookbook.asciidoc
@@ -1,5 +1,7 @@
 include::primitive-data/primitive-data.asciidoc[]
 
+include::basics/basics.asciidoc[]
+
 include::composite-data/composite-data.asciidoc[]
 
 include::local-io/local-io.asciidoc[]


### PR DESCRIPTION
The reference to the "basics" sub-directory appears to be missing from clojure-cookbook.asciidoc, so none of the recipes in that sub-directory are included in drafts.
I wasn't sure if this was intentional, and thought a pull request might be the easiest way to sort things out.

Hope this helps
