### PR TITLE
Use updated Machine Head version

### DIFF
--- a/network-io/communicating-with-mqtt/communicating-with-mqtt.asciidoc
+++ b/network-io/communicating-with-mqtt/communicating-with-mqtt.asciidoc
@@ -16,7 +16,7 @@ communicate by publishing messages or subscribing messages on specific
 available at _tcp://test.mosquitto.org:1883_  (of course, you need a functional Internet connection on your machine). 
 
 
-Invoke the REPL using *+lein try clojurewerkz/machine_head 1.0.0-beta1+* and then run the 
+Invoke the REPL using *+lein try clojurewerkz/machine_head 1.0.0-beta2+* and then run the 
 following code for subscribing to messages.
 
 [source,clojure]


### PR DESCRIPTION
`1.0.0-beta2` is out and I really would like the book
to refer to it instead of `beta1`.
