### PR TITLE
Fix code sample in formatting-strings.

### DIFF
--- a/primitive-data/strings/formatting-strings/formatting-strings.asciidoc
+++ b/primitive-data/strings/formatting-strings/formatting-strings.asciidoc
@@ -34,7 +34,7 @@ For greater control over how values are printed use the +format+ function.
 ;; Produce a filename with a zero-padded sortable index
 (defn filename [name i]
   (format "%03d-%s" i name)) <1>
-   
+
 (filename "my-awesome-file.txt" 42)
 ;; -> "042-my-awesome-file.txt"
 
@@ -48,13 +48,15 @@ For greater control over how values are printed use the +format+ function.
 
 (->> (concat [header] employees)
      (map tableify)
-     (map println))
-;; First Name           | Last Name            | Employee ID         
-;; Ryan                 | Neufeld              | 2                   
-;; Luke                 | Vanderhart           | 1                   
+     (mapv println))
+;; *out*
+;; First Name           | Last Name            | Employee ID
+;; Ryan                 | Neufeld              | 2
+;; Luke                 | Vanderhart           | 1
+;; -> [nil nil nil]
 ----
 <1> The +0+ flag indicates to pad a digit ("+d+") with zeroes (three, in this case.)
-<2> The +-+ flag indicates to left justify the string ("+s+") by 10 characters.
+<2> The +-+ flag indicates to left justify the string ("+s+") by 20 characters.
 
 ==== Discussion
 
@@ -69,7 +71,7 @@ formatting for a value will suffice, and use +format+ when you need
 more control over how values display.
 
 .Format Strings
-**** 
+****
 The first argument passed to +format+ is what is
 called a "format string." The syntax for these strings isn't new or
 unique to Clojure or even Java, but in fact comes from C's +printf+
@@ -99,7 +101,7 @@ places (just like the Dewey Decimal system.)
 ----
 
 Visit http://docs.oracle.com/javase/1.5.0/docs/api/java/util/Formatter.html[java.util.Formatter] to learn more about formatting strings.
-**** 
+****
 
 ==== See Also
 


### PR DESCRIPTION
Lazy (map println) wasn't producing output like the book showed. The repl output was mixed in with the println output. Switching to a non-lazy mapv fixed the problem. Also converted to follow the _out_ convention.
