### PR TITLE
Non-sorted sets end up in hash order.

### DIFF
--- a/composite-data/sets/adding-and-removing/adding-and-removing.asciidoc
+++ b/composite-data/sets/adding-and-removing/adding-and-removing.asciidoc
@@ -16,10 +16,10 @@ and any number of items to add.
 [source,clojure]
 ----
 (conj #{:a :b :c} :d)
-;; -> #{:a :b :c :d}
+;; -> #{:a :c :b :d}
 
 (conj #{:a :b :c} :d :e)
-;; -> #{:a :b :c :d :e}
+;; -> #{:a :c :b :d :e}
 ----
 
 To remove one or more items, use the +disj+ function, which is
@@ -62,4 +62,3 @@ invoking them with large numbers of arguments.
 * <<sec_adding_to_a_list>>
 * <<sec_adding_to_a_vector>>
 * <<sec_set_operations>>
-


### PR DESCRIPTION
The order of the sets in the output here isn't what most people will see. Sets aren't ordered, but this might confuse people.

Feel free to deny the merge request. I'm not sure if this needs to be fixed or not.
