### PR TITLE
Add example to applying-functions-to-maps

### DIFF
--- a/composite-data/maps/applying-functions-to/applying-functions-to.asciidoc
+++ b/composite-data/maps/applying-functions-to/applying-functions-to.asciidoc
@@ -45,6 +45,9 @@ any needs you have.
   provided function must return a pair (a two-element sequence.)"
   [m f]
   (into {} (map (fn [[k v]] (f k v)) m)))
+
+(map-kv {"a" 1 "b" 1} (fn [k v] [(keyword k) (inc v)]))
+;; -> {:a 2, :b 2}
 ----
 
 ==== Discussion


### PR DESCRIPTION
Add an example for the map-kv function, similar to the examples provided for the previous two functions.
