### PR TITLE
Pluralizing monkey returns monkey, not virus :)

### DIFF
--- a/primitive-data/strings/inflecting-strings/inflecting-strings.asciidoc
+++ b/primitive-data/strings/inflecting-strings/inflecting-strings.asciidoc
@@ -29,7 +29,7 @@ that word if count is not one.
 (require '[inflections.core :as inf])
 
 (inf/pluralize 1 "monkey")
-;; -> "1 virus"
+;; -> "1 monkey"
 
 (inf/pluralize 12 "monkey")
 ;; -> "12 monkeys"


### PR DESCRIPTION
The virus was probably a leftover from some previous version...
