### PR TITLE
fix asciidoc warnings from callouts and incorrect WARNING spec

### DIFF
--- a/deployment-and-distribution/releasing-a-library/releasing-a-library.asciidoc
+++ b/deployment-and-distribution/releasing-a-library/releasing-a-library.asciidoc
@@ -33,8 +33,8 @@ WARNING: please set :description in project.clj.
 WARNING: please set :url in project.clj.
 No credentials found for clojars (did you mean `lein deploy clojars`?)
 See `lein help deploy` for how to configure credentials.
-Username: <1>
-Password: <2>
+Username: #<1>
+Password: #<2>
 Wrote .../my-first-project-ryan-neufeld/pom.xml
 Created .../my-first-project-ryan-neufeld-0.1.0-SNAPSHOT.jar
 Could not find metadata my-first-project-ryan-neufeld:.../0.1.0-SNAPSHOT/maven-metadata.xml \

--- a/general-computing/core-logic/core-logic.asciidoc
+++ b/general-computing/core-logic/core-logic.asciidoc
@@ -224,7 +224,7 @@ could be followed by any other sequence of numbers/strings/lists etc.
 +_0+ is an unbound variable, since there was no further restriction on
 the list, other than +1+ being an element.
 
-[WARN]
+[WARNING]
 ====
 +clojure.core.logic/run*+ is a macro that asks for all possible
 solutions. Asking for all of the lists that contain a +1+ will not

--- a/local-io/files/copy-file/copy-file.asciidoc
+++ b/local-io/files/copy-file/copy-file.asciidoc
@@ -55,11 +55,11 @@ will catch any exceptions and optionally overwrite.
 (defn safe-copy [source-path destination-path & opts]
   (let [source (clojure.java.io/file source-path)
         destination (clojure.java.io/file destination-path)
-        options (merge {:overwrite false} (apply hash-map opts))] <1>
-    (if (and (.exists source)	   	  	 	  	  <2>
+        options (merge {:overwrite false} (apply hash-map opts))] ; <1>
+    (if (and (.exists source)	   	  	 	  	  ; <2>
              (or (:overwrite options) (= false (.exists destination))))
       (try
-        (= nil (clojure.java.io/copy source destination))	  <3>
+        (= nil (clojure.java.io/copy source destination))	  ; <3>
         (catch Exception e (str "exception: " (.getMessage e))))
       false)))
 

--- a/primitive-data/math/fuzzy-comparison/fuzzy-comparison.asciidoc
+++ b/primitive-data/math/fuzzy-comparison/fuzzy-comparison.asciidoc
@@ -81,9 +81,9 @@ function +fuzzy-comparator+ that returns a comparator with a given tolerance.
 ----
 (defn fuzzy-comparator [tolerance]
   (fn [x y]
-    (if (fuzzy= tolerance x y) <1>
+    (if (fuzzy= tolerance x y) ; <1>
       0
-      (compare x y)))) <2>
+      (compare x y)))) ; <2>
 
 (sort (fuzzy-comparator 10) [100 11 150 10 9])
 ;; -> (11 10 9 100 150) ; 100 and 150 have moved, but not 11, 10, 9

--- a/primitive-data/math/simple-statistics/simple-statistics.asciidoc
+++ b/primitive-data/math/simple-statistics/simple-statistics.asciidoc
@@ -42,11 +42,11 @@ considering the mean of the *two* middle values.
         cnt (count sorted)
         halfway (int (/ cnt 2))]
     (if (odd? cnt)
-      (nth sorted halfway) <1>
+      (nth sorted halfway) ; <1>
       (let [bottom (dec halfway)
             bottom-val (nth sorted bottom)
             top-val (nth sorted halfway)]
-        (mean [bottom-val top-val]))))) <2>
+        (mean [bottom-val top-val]))))) ; <2>
 
 (median [5 2 4 1 3])
 ;; -> 3

--- a/primitive-data/strings/formatting-strings/formatting-strings.asciidoc
+++ b/primitive-data/strings/formatting-strings/formatting-strings.asciidoc
@@ -33,14 +33,14 @@ For greater control over how values are printed use the +format+ function.
 ----
 ;; Produce a filename with a zero-padded sortable index
 (defn filename [name i]
-  (format "%03d-%s" i name)) <1>
+  (format "%03d-%s" i name)) ; <1>
 
 (filename "my-awesome-file.txt" 42)
 ;; -> "042-my-awesome-file.txt"
 
 ;; Create a table using justification
 (defn tableify [row]
-  (apply format "%-20s | %-20s | %-20s" row)) <2>
+  (apply format "%-20s | %-20s | %-20s" row)) ; <2>
 
 (def header ["First Name", "Last Name", "Employee ID"])
 (def employees [["Ryan", "Neufeld", 2]


### PR DESCRIPTION
Commenting the callouts eliminates asciidoc warnings but also allows the code to be pasted in REPL without issue.
