### PR TITLE
fix incorrect file name and source type

### DIFF
--- a/distributed-computation/cascalog/etl/etl.asciidoc
+++ b/distributed-computation/cascalog/etl/etl.asciidoc
@@ -84,10 +84,10 @@ Create the file _src/cookbook/etl.clj_ and add a query to it.
     (vec->csv ?authors :> ?out-csv)))
 ----
 
-Create a file with input data in _samples/books/books.csv_.
+Create a file with input data in _samples/books/books.json_.
 
-._samples/books/books.csv_
-[source,csv]
+._samples/books/books.json_
+[source,json]
 ----
 {"name": "Clojure Cookbook", "authors": ["Ryan", "Luke"]}
 ----


### PR DESCRIPTION
The samples repo referenced in the recipe contains books.json (not books.csv) and the data provided in the recipe is json.
