### PR TITLE
Fixed http* links

### DIFF
--- a/databases/datomic/transact-retract-data.asciidoc
+++ b/databases/datomic/transact-retract-data.asciidoc
@@ -113,5 +113,5 @@ data permanently.
 
 ==== See Also
 
-* _http://blog.datomic.com/2013/05/excision.html_, the
-  _http://datomic.com_ blog post covering the excision feature.
+* http://blog.datomic.com/2013/05/excision.html, the
+  http://datomic.com blog post covering the excision feature.

--- a/deployment-and-distribution/creating-executable-jar/creating-executable-jar.asciidoc
+++ b/deployment-and-distribution/creating-executable-jar/creating-executable-jar.asciidoc
@@ -171,7 +171,7 @@ releasing libraries.].
 
 Without its dependencies included--namely Clojure--you'll need to do a bit more
 work to run the foo application. First, download Clojure 1.5.1 from
-_http://clojure.org/downloads_. Then invoke +foo.core+  via the *+java+*
+http://clojure.org/downloads. Then invoke +foo.core+  via the *+java+*
 command, including _clojure-1.5.1.jar_ and _foo-0.1.0-SNAPSHOT.jar_ on the
 classpath (via the +-cp+ option).
 

--- a/frontmatter/frontmatter.asciidoc
+++ b/frontmatter/frontmatter.asciidoc
@@ -89,7 +89,7 @@ we recommend one of the following books:
 
 Finally, you should look at the source code for this book itself,
 which is freely available on Github at
-_https://github.com/clojure-cookbook/clojure-cookbook_. The selection
+https://github.com/clojure-cookbook/clojure-cookbook. The selection
 of recipes available online is larger than that in the print version,
 and we are still accepting pull requests for new recipes that might
 someday make it in to a future edition of this book.
@@ -184,11 +184,11 @@ minimum of 6 will do. For Leiningen, you should have at least
 version 2.2.
 
 If you don't have Java installed (or would like to upgrade), visit
-_http://www.oracle.com/technetwork/java/javase/downloads/index.html_ for
+http://www.oracle.com/technetwork/java/javase/downloads/index.html for
 instructions on downloading and installing the Java JDK.
 
 To install Leiningen, follow the installation instructions on
-Leiningen's website (_http://leiningen.org/_). If you already have
+Leiningen's website (http://leiningen.org/). If you already have
 Leiningen installed, get the latest version by executing the command
 *+lein upgrade+*. If you aren't familiar with Leiningen, visit the
 https://github.com/technomancy/leiningen/blob/stable/doc/TUTORIAL.md[tutorial]
@@ -210,7 +210,7 @@ user=> *clojure-version*
 ====
 Some recipes have accompanying online materials available on GitHub.
 If you do not have Git installed on your system, follow the
-instructions at _https://help.github.com/articles/set-up-git_ to
+instructions at https://help.github.com/articles/set-up-git to
 enable you to checkout a GitHub repository locally.
 ====
 

--- a/general-computing/core-logic/core-logic.asciidoc
+++ b/general-computing/core-logic/core-logic.asciidoc
@@ -335,6 +335,6 @@ with some basic indexing can greatly improve the query performance.
 
 * The Reasoned Schemer - By Daniel P. Friedman, William E. Byrd and Oleg Kiselyov
 * The https://github.com/clojure/core.logic/wiki[+core.logic+ wiki]
-* _http://minikanren.org/_
+* http://minikanren.org/
 * The https://github.com/clojure/core.logic[+core.logic+ repository] for examples of using *clojure.core.logic/to-stream*
 * https://github.com/clojure/core.match[+core.match+], a (non-unification) matching library with some similar ideas, described briefly in <<sec_core_match_parser>>

--- a/general-computing/extend-built-in/extend-built-in.asciidoc
+++ b/general-computing/extend-built-in/extend-built-in.asciidoc
@@ -76,6 +76,6 @@ If you already had functions to use, then it would make sense to use
 
 ==== See Also
 
-* _http://stackoverflow.com/a/4513556_, an excellent explanation of why
+* http://stackoverflow.com/a/4513556, an excellent explanation of why
   protocols exist as it relates to the _Expression Problem_ 
   by Jörg W Mittag on StackOverflow.

--- a/general-computing/main/main.asciidoc
+++ b/general-computing/main/main.asciidoc
@@ -16,7 +16,7 @@ argument to +clojure.main+.
 [NOTE]
 ====
 To follow along with this recipe, you can download a version of
-_clojure.jar_ at _http://clojure.org/downloads_.
+_clojure.jar_ at http://clojure.org/downloads.
 ====
 
 For example, given a file _my_clojure_program.clj_ with the contents:

--- a/network-io/communicating-with-mqtt/communicating-with-mqtt.asciidoc
+++ b/network-io/communicating-with-mqtt/communicating-with-mqtt.asciidoc
@@ -189,14 +189,14 @@ some actions based on an alarm that the code has received.
 
 ==== See Also
 
-* The details on MQTT protocol at _http://mqtt.org/_
+* The details on MQTT protocol at http://mqtt.org/
 * http://clojuremqtt.info/[Machine Head Documentation] of the
   https://github.com/clojurewerkz/machine_head[Machine_Head] library
 * http://www.eclipse.org/paho/[Eclipse Paho library], the Java
   library, that Machine Head uses under the hood to communicate using
   MQTT.
 * Mosquitto, an open source message broker that implements MQTT 
-  protocol at _http://mosquitto.org/_
+  protocol at http://mosquitto.org/
 * http://www.redbooks.ibm.com/abstracts/sg248054.html[Building Smarter
   Planet Solutions with MQTT and IBM WebSphere MQ Telemetry, An IBM
   Redbooks publication] explains MQTT in more details.

--- a/network-io/queueing-with-rabbitmq/queueing-with-rabbitmq.asciidoc
+++ b/network-io/queueing-with-rabbitmq/queueing-with-rabbitmq.asciidoc
@@ -22,7 +22,7 @@ $ lein try com.novemberain/langohr
 
 In order to follow along with this recipe, you need to have RabbitMQ
 installed and running. You can find details on how to install RabbitMQ
-here: _http://www.rabbitmq.com/download.html_.
+here: http://www.rabbitmq.com/download.html.
 
 Once installed, start a standalone RabbitMQ server with the command
 +rabbitmq-server+.

--- a/webapps/ring/compojure/compojure.asciidoc
+++ b/webapps/ring/compojure/compojure.asciidoc
@@ -11,7 +11,7 @@ You want an easy way to route URLs to specific Ring handler functions.
 
 Use the Compojure library (https://github.com/weavejester/compojure) to add routing to your app.
 
-To follow along with this recipe, clone the _https://github.com/clojure-cookbook/ringtest_ repository and overwrite _src/ringtest.clj_.
+To follow along with this recipe, clone the https://github.com/clojure-cookbook/ringtest repository and overwrite _src/ringtest.clj_.
 
 ._src/ringtest.clj_
 [source, clojure]
@@ -107,4 +107,4 @@ which bundles a number of ring middlewares into one convenient wrapper.
 
 ==== See Also
 
-* _http://compojure.org_
+* http://compojure.org


### PR DESCRIPTION
The prefixed and suffixed '_' forced a conversion to <em/> instead of <a/> elements in HTML output. AsciiDoc does not need links to be marked up. Use http://foo.bar instead of _http://foo.bar_.
