### PR TITLE
Fix source-highlight bootstrap

### DIFF
--- a/script/asciidoc/bootstrap_osx.sh
+++ b/script/asciidoc/bootstrap_osx.sh
@@ -69,6 +69,7 @@ grep clojure "$LANG_MAP_FILE" >/dev/null || {
 
   echo "********** Appending to $LANG_MAP_FILE"
   cat <<END >> "$LANG_MAP_FILE"
+
 clojure = clojure.lang
 csv = plain.lang
 json = json.lang


### PR DESCRIPTION
Prevent bootstrap script from doing this to `source-highlight`'s `lang.map`:

```
lua = lua.lang
ly = lilypond.langclojure = clojure.lang
m4 = m4.lang
```
