### PR TITLE
off-by-one error in the range output example

### DIFF
--- a/00_frontmatter/conventions.asciidoc
+++ b/00_frontmatter/conventions.asciidoc
@@ -31,7 +31,7 @@ a function/var or shortening lengthy output:
 (def one 1)
 
 (into [] (range 1 20))
-;; -> [1 2 ... 20]
+;; -> [1 2 ... 19]
 ----
 
 When an expression produces output to +STDOUT+ or +STDERR+, it is


### PR DESCRIPTION
Typo in recipe
