### PR TITLE
use (quot n d) instead of (int (/ n d))

### DIFF
--- a/01_primitive-data/1-20_simple-statistics.asciidoc
+++ b/01_primitive-data/1-20_simple-statistics.asciidoc
@@ -41,7 +41,7 @@ considering the mean of the _two_ middle values:
 (defn median [coll]
   (let [sorted (sort coll)
         cnt (count sorted)
-        halfway (int (/ cnt 2))]
+        halfway (quot cnt 2)]
     (if (odd? cnt)
       (nth sorted halfway) ; <1>
       (let [bottom (dec halfway)

--- a/06_databases/6-02_SQL-database-connection-pooling.asciidoc
+++ b/06_databases/6-02_SQL-database-connection-pooling.asciidoc
@@ -74,8 +74,8 @@ specification map:
 (defn pooled-datasource [db-spec]
   (let [{:keys [classname subprotocol subname user password
                 init-pool-size max-pool-size idle-time partitions]} db-spec
-        min-connections (inc (int (/ init-pool-size partitions)))
-        max-connections (inc (int (/ max-pool-size partitions)))
+        min-connections (inc (quot init-pool-size partitions))
+        max-connections (inc (quot max-pool-size partitions))
         cpds (doto (BoneCPDataSource.)
                    (.setDriverClass classname)
                    (.setJdbcUrl (str "jdbc:" subprotocol ":" subname))
@@ -151,7 +151,7 @@ tested.
 
 Pooled data resources (threads and database connections) may be released by
 calling the +close+ method on the +BoneCPDataSource+ class of the(((exceptions/errors, SQL exceptions)))
-library. Attempting to reuse the pooled data source after it is closed will result 
+library. Attempting to reuse the pooled data source after it is closed will result
 in an SQL exception:
 
 [source,clojure]


### PR DESCRIPTION
Why use coercion when the right function (`quot`) is already available?

Also, I'd suggest mentioning in the text that `quot` means 'quotient', not 'quote'.
