### PR TITLE
Update 7-04_forms.asciidoc:  correct :params -> :form-params

### DIFF
--- a/07_webapps/7-04_forms.asciidoc
+++ b/07_webapps/7-04_forms.asciidoc
@@ -42,7 +42,7 @@ To follow along with this recipe, clone the https://github.com/clojure-cookbook/
   "Show a form requesting the user's name, or greet them if they
   submitted the form"
   [req]
-  (let [name (get-in req [:params "name"])]
+  (let [name (get-in req [:form-params "name"])]
     (if name
       (show-name name)
       (show-form))))


### PR DESCRIPTION
The discussion discusses the reasons to use :form-params instead of :params, but the example actually used :params.

Alan
