### PR TITLE
Update 10-06_tracing.asciidoc: make dev dependency literal in text

### DIFF
--- a/10_testing/10-06_tracing.asciidoc
+++ b/10_testing/10-06_tracing.asciidoc
@@ -15,8 +15,8 @@ code as it runs.
 
 Before starting, add `[org.clojure/tools.trace "0.7.6"]` to your
 project's dependencies under the +:development+ profile (in the vector
-at the `[:profiles :dev :dependencies]` path instead of the
-`[:dependencies]` path). Alternatively, start a REPL using +lein-try+:
+at the `:profiles {:dev {:dependencies [...]}}` path instead of the
+`:dependencies [...]` path). Alternatively, start a REPL using +lein-try+:
 
 [source,shell-session]
 ----


### PR DESCRIPTION
The vector notation for the dev dependency was a bit confusing.  I think the reader will understand a literal example a bit more easily.
Alan
