### PR TITLE
Update 10-03_generative.asciidoc

### DIFF
--- a/10_testing/10-03_generative.asciidoc
+++ b/10_testing/10-03_generative.asciidoc
@@ -149,6 +149,9 @@ The function under test is simply the function to call. Over the
 course of the generative test, it will be called many times, each time
 with different values.
 
+***** The code snippets have no example of using +:tag+ The following 4 
+paragraphs are thus a bit confusing! *****
+
 The argument specification is a vector of argument names and should
 match the signature of the function under test. Each argument should
 have _metadata_ attached. Specifically, it should have a +:tag+


### PR DESCRIPTION
You discuss the :tag metadata, but show no examples of its use.  This is confusing to the reader, as it looks like part of the text was deleted.

Should either add examples of :tag or, perhaps, remove reference to :tag.   Other ideas?

Alan
