### PR TITLE
Update 4-18_read-property-file.asciidoc

### DIFF
--- a/04_local-io/4-18_read-property-file.asciidoc
+++ b/04_local-io/4-18_read-property-file.asciidoc
@@ -83,7 +83,7 @@ capability to parse values into numbers or Booleans, and providing
 default values.
 
 By default, ++propertea++'s +read-properties+ function treats all
-property values as strings. Consider the following property file with
+property values as strings. Consider a file +other.properties+ with
 an integer and Boolean key:
 
 ----


### PR DESCRIPTION
Unless the file other.properties is mentioned in the text, it is not clear at first that it refers to intkey=42 / booleankey=true
