### PR TITLE
Update 1-05_integer-to-character-conversions.asciidoc

### DIFF
--- a/01_primitive-data/1-05_integer-to-character-conversions.asciidoc
+++ b/01_primitive-data/1-05_integer-to-character-conversions.asciidoc
@@ -45,9 +45,10 @@ code point specified by the integer:
 (char 945)
 ;; -> \α
 
-(reduce #(str %1 (char %2))
-        ""
-        [115 101 99 114 101 116 32 109 101 115 115 97 103 101 115])
+
+(def codes [115 101 99 114 101 116 32 109 101 115 115 97 103 101 115])
+;; -> #'user/codes
+(apply str (map char codes))
 ;; -> "secret messages"
 ----
 


### PR DESCRIPTION
Using reduce with an anonymous function to build up a string from ascii codes is a bit of overkill, and non-intuitive for new users in the first chapter.

I think it is much more straightforward to use a simple "map" call to convert from integer to char, the "apply str" to convert the individual chars into a single string.

I also put the vector of ascii codes into a separate vector "codes" with the idea that 2 simple steps are faster & easier to understand (esp. in Ch #1) than a single large step.
