### PR TITLE
embed source-highlight files for json lang/style and update bootstrap.sh

### DIFF
--- a/script/asciidoc/bootstrap.sh
+++ b/script/asciidoc/bootstrap.sh
@@ -22,6 +22,15 @@
 
 set -e
 
+PROJECT_BASE=$(dirname $0)/../../
+OS=`uname -s`
+if [ "${OS}" = "Darwin" ] ; then
+    PROJECT_ROOT=`greadlink -f ${PROJECT_BASE}`
+else
+    PROJECT_ROOT=`readlink -f ${PROJECT_BASE}`
+fi
+export PROJECT_ROOT
+
 # Determine package installation command
 if [[ -n "$PACKAGE_INSTALL" ]]; then
   echo "Using '$PACKAGE_INSTALL' as install command"
@@ -69,8 +78,8 @@ JSON_STYLE_FILE="${SOURCE_HIGHLIGHT_DIR}/json.style"
 TEXT_LANG_FILE="${SOURCE_HIGHLIGHT_DIR}/text.lang"
 
 CLOJURE_LANG_SOURCE="https://gist.github.com/alandipert/265810/raw/8dec04317e02187b03e96bb1e0206e154e0ae5e2/clojure.lang"
-JSON_LANG_SOURCE="https://raw.github.com/freeformsystems/rlx/master/highlight/json.lang"
-JSON_STYLE_SOURCE="https://raw.github.com/freeformsystems/rlx/master/highlight/json.style"
+JSON_LANG_SOURCE="${PROJECT_ROOT}/script/asciidoc/source-highlight/json.lang"
+JSON_STYLE_SOURCE="${PROJECT_ROOT}/script/asciidoc/source-highlight/json.style"
 
 # uncomment the following to debug/start fresh
 # does not clean LANG_MAP_FILE
@@ -80,8 +89,8 @@ JSON_STYLE_SOURCE="https://raw.github.com/freeformsystems/rlx/master/highlight/j
 test -f "$CLOJURE_LANG_FILE" || (echo "** Adding $CLOJURE_LANG_FILE **" && $SUDO curl --location --silent --output "$CLOJURE_LANG_FILE" "$CLOJURE_LANG_SOURCE")
 
 # JSON highlighting support
-test -f "$JSON_LANG_FILE" || (echo "** Adding $JSON_LANG_FILE **" && $SUDO curl --location --silent --output "$JSON_LANG_FILE" "$JSON_LANG_SOURCE")
-test -f "$JSON_STYLE_FILE" || (echo "** Adding $JSON_STYLE_FILE **" && $SUDO curl --location --silent --output "$JSON_STYLE_FILE" "$JSON_STYLE_SOURCE")
+test -f "$JSON_LANG_FILE" || (echo "** Adding $JSON_LANG_FILE **" && $SUDO cp  "$JSON_LANG_SOURCE" "$JSON_LANG_FILE" )
+test -f "$JSON_STYLE_FILE" || (echo "** Adding $JSON_STYLE_FILE **" && $SUDO cp "$JSON_STYLE_SOURCE" "$JSON_STYLE_FILE" )
 
 # CSV/text/text highlighting
 # This is to avoid errors more than actually highlight anything.

--- a/script/asciidoc/source-highlight/json.lang
+++ b/script/asciidoc/source-highlight/json.lang
@@ -1,0 +1,19 @@
+# JSON lang definition file
+# Formerly https://raw.github.com/freeformsystems/rlx/master/highlight/json.lang
+
+# for string types
+(keyquote,key,keyquote,colon,valquote,string,valquote) = `(")([^"]+)(")(\s*:)(\s*")((?:\\"|.)*?)(")`
+
+# for string primitives
+(valquote,string,valquote) = `(^")((?:\\"|.)*?)("$)`
+
+# for non-string types and string values (array of strings)
+(keyquote,key,keyquote,colon) = `(")([^"]+)(")(\s*:?\s*)`
+
+# duplicated from number.lang - can just include
+number = 
+'\<[+-]?((0x[[:xdigit:]]+)|(([[:digit:]]*\.)?
+[[:digit:]]+([eE][+-]?[[:digit:]]+)?))u?((int(?:8|16|32|64))|L)?\>'
+
+symbol = ",","{","}","[","]"
+keyword = "true|false|null"

--- a/script/asciidoc/source-highlight/json.style
+++ b/script/asciidoc/source-highlight/json.style
@@ -1,0 +1,12 @@
+string red b;
+keyword blue;
+number blue;
+type pink;
+normal black;
+symbol blue;
+
+// for JSON
+key bg:black;
+keyquote bg:black;
+valquote red;
+colon cyan;


### PR DESCRIPTION
The source-highlight files for json are gone from the original location.
Added json.style and json.lang directly to cookbook repo and fixed bootstrap to pull from there.
Tested on OS X 10.9.4.
