### PR TITLE
Fix mislabeling of \f as linefeed.

### DIFF
--- a/01_primitive-data/1-02_managing-whitespace.asciidoc
+++ b/01_primitive-data/1-02_managing-whitespace.asciidoc
@@ -36,8 +36,8 @@ pass:[<phrase role='keep-together'><literal>clojure.string/replace</literal></ph
 
 What constitutes whitespace in Clojure? The answer depends on the
 function: some are more liberal than others, but you can safely assume
-that a space ( ), tab (+\t+), newline (+\n+), carriage return (+\r+), line
-feed (+\f+), and vertical tab (+\x0B+) will be treated as whitespace.
+that a space ( ), tab (+\t+), newline/linefeed (+\n+), carriage return (+\r+),
+form feed (+\f+), and vertical tab (+\x0B+) will be treated as whitespace.
 This set of characters is the set matched by +\s+ in Java's regular
 expression implementation.
 


### PR DESCRIPTION
\f is form feed, which is a different concept (more a page break than anything
else). \n can be referred to as newline or linefeed.

Let me know if I've screwed anything up; this tripped one of our developers
up when we were looking into some linefeed issues :)