### PR TITLE
Use val/key instead of second/first in simple-statistics recipe.

### DIFF
--- a/01_primitive-data/1-20_simple-statistics.asciidoc
+++ b/01_primitive-data/1-20_simple-statistics.asciidoc
@@ -67,11 +67,11 @@ retrieve the discrete list of modes:
 ----
 (defn mode [coll]
   (let [freqs (frequencies coll)
-        occurrences (group-by second freqs)
+        occurrences (group-by val freqs)
         modes (last (sort occurrences))
         modes (->> modes
-                   second
-                   (map first))]
+                   val
+                   (map key))]
      modes))
 
 (mode [:alan :bob :alan :greg])


### PR DESCRIPTION
Both group-by and frequencies produce maps. I think it's easier for the readers to comprehend by using the map entry manipulating functions (val/key) rather than the general purpose functions (second/first).