### PR TITLE
Fix a typo in 2-09_get-item-at-index.asciidoc

### DIFF
--- a/02_composite-data/2-09_get-item-at-index.asciidoc
+++ b/02_composite-data/2-09_get-item-at-index.asciidoc
@@ -71,7 +71,7 @@ not found:
 [source,clojure]
 ----
 (get [:a :b :c] 5)
-;; -> :nil
+;; -> nil
 
 (get [:a :b :c] 5 :not-found)
 ;; -> :not-found


### PR DESCRIPTION
The function **get** returns **nil**, not the keyword **:nil**. Should be a typo.