### PR TITLE
Update 2-13_testing-set-membership.asciidoc

### DIFF
--- a/02_composite-data/2-13_testing-set-membership.asciidoc
+++ b/02_composite-data/2-13_testing-set-membership.asciidoc
@@ -115,7 +115,7 @@ itself is both easy and idiomatic:
 ----
 
 This snippet first creates an infinite lazy sequence consisting of
-random numbers between 1 and 10, using +repeatedly+ to call
+random integers between 0 (inclusive) and 10 (exclusive), using +repeatedly+ to call
 +rand-int+ (wrapped in an anonymous function) over and over. Then it
 feeds this sequence through a filter, with a set of the numbers 1&#x2013;3
 as the filter predicate.


### PR DESCRIPTION
(rand-int 10) returns [0,10). Maybe no need to be so accurate, which makes it a little awkward. I think both 'between 0 and 10' and 'between 0 and 9' are ok but 0 should be included.