### PR TITLE
Use find instead of first to produce predictable result in 2-20_as-sequences.asciidoc

### DIFF
--- a/02_composite-data/2-20_as-sequences.asciidoc
+++ b/02_composite-data/2-20_as-sequences.asciidoc
@@ -80,6 +80,20 @@ their sort order in the map. For example:
 ;; -> ([:a 1] [:b 2] [:c 3] [:d 4])
 ----
 
+It's also possible to retrieve the map entry for a particular key.
+Use the +find+ function, which is similar to +get+ except two facts:
+first, it returns map entries; second, it does'nt accept an optional
+default return value:
+
+[source,clojure]
+----
+(find {:name "Kvothe" :class "Bard"} :name)
+;; -> [:name "Kvothe"]
+
+(find {:name "Kvothe" :class "Bard"} :race)
+;; -> nil
+----
+
 There is another interesting fact about the entry values in this
 sequence. They are printed as vectors, and they _are_ vectors insofar
 as they implement the full vector interface. However, their concrete

--- a/02_composite-data/2-20_as-sequences.asciidoc
+++ b/02_composite-data/2-20_as-sequences.asciidoc
@@ -92,7 +92,7 @@ be used to retrieve the key and value of an entry:
 
 [source,clojure]
 ----
-(def entry (first {:a 1 :b 2}))
+(def entry (find {:a 1 :b 2} :a))
 
 (class entry)
 ;; -> clojure.lang.MapEntry


### PR DESCRIPTION
The result for **(first {:a 1 :b 2})** is not predictable and I find the code snippet works differently for me (**(key entry)** returns :b and **(val entry)** returns 2). It's also ok to use a sorted map but I think it's a good place to introduce the function **find** as it's not explained elsewhere.