### PR TITLE
Update 2-26_determining-if-a-collection-holds-one-of-several-values.asciidoc

### DIFF
--- a/02_composite-data/2-26_determining-if-a-collection-holds-one-of-several-values.asciidoc
+++ b/02_composite-data/2-26_determining-if-a-collection-holds-one-of-several-values.asciidoc
@@ -42,9 +42,9 @@ you're using to test a collection with. Consider the following:
 ----
 
 Because the +some+ function returns the _value_ returned from the
-predicate function, not just +true+ or +false+, using it with sets
+predicate function when it's logically true, or +nil+ otherwise, not just +true+ or +false+, using it with sets
 that contain +nil+ or +false+ probably isn't what you want--it will
-return +nil+ or +false+ if the item actually _is_ in the set. The simplest solution is to test for +nil+ or +false+ separately,
+return +nil+ if the item actually _is_ in the set. The simplest solution is to test for +nil+ or +false+ separately,
 using the +nil?+ or +false?+ predicate functions built into Clojure:
 
 [source,clojure]


### PR DESCRIPTION
The function **some** returns **nil**, not **false**, when the predicate returns **false**.