### PR TITLE
Update 3-02_interactive-docs.asciidoc to conform with the Conventions

### DIFF
--- a/03_general-computing/3-02_interactive-docs.asciidoc
+++ b/03_general-computing/3-02_interactive-docs.asciidoc
@@ -11,50 +11,56 @@ From a REPL, you want to read documentation for a function.((("REPL (read-eval-p
 
 Print the documentation for a function at the REPL with the +doc+ macro:
 
-[source,shell-session]
+[source,clojure]
 ----
 user=> (doc conj)
- -------------------------
-clojure.core/conj
-([coll x] [coll x & xs])
-  conj[oin]. Returns a new collection with the xs
-    'added'. (conj nil item) returns (item).  The 'addition' may
-    happen at different 'places' depending on the concrete type.
+;; -> nil
+;; *out*
+;; -------------------------
+;; clojure.core/conj
+;; ([coll x] [coll x & xs])
+;;   conj[oin]. Returns a new collection with the xs
+;;     'added'. (conj nil item) returns (item).  The 'addition' may
+;;     happen at different 'places' depending on the concrete type.
 ----
 
 Print the source code for a function at the REPL with the +source+ macro:
 
-[source,shell-session]
+[source,clojure]
 ----
 user=> (source reverse)
-(defn reverse
-  "Returns a seq of the items in coll in reverse order. Not lazy."
-  {:added "1.0"
-   :static true}
-  [coll]
-    (reduce1 conj () coll))
+;; -> nil
+;; *out*
+;; (defn reverse
+;;   "Returns a seq of the items in coll in reverse order. Not lazy."
+;;   {:added "1.0"
+;;    :static true}
+;;   [coll]
+;;     (reduce1 conj () coll))
 ----
 
 Find functions with documentation matching a given regular expression using +find-doc+:
 
-[source,shell-session]
+[source,clojure]
 ----
 user=> (find-doc #"defmacro")
- -------------------------
-clojure.core/definline
-([name & decl])
-Macro
-  Experimental - like defmacro, except defines a named function whose
-  body is the expansion, calls to which may be expanded inline as if
-  it were a macro. Cannot be used with variadic (&) args.
- -------------------------
-clojure.core/defmacro
-([name doc-string? attr-map? [params*] body]
- [name doc-string? attr-map? ([params*] body) + attr-map?])
-Macro
-  Like defn, but the resulting function name is declared as a
-  macro and will be used as a macro by the compiler when it is
-  called.
+;; -> nil
+;; *out*
+;; -------------------------
+;; clojure.core/definline
+;; ([name & decl])
+;; Macro
+;;   Experimental - like defmacro, except defines a named function whose
+;;   body is the expansion, calls to which may be expanded inline as if
+;;   it were a macro. Cannot be used with variadic (&) args.
+;; -------------------------
+;; clojure.core/defmacro
+;; ([name doc-string? attr-map? [params*] body]
+;;  [name doc-string? attr-map? ([params*] body) + attr-map?])
+;; Macro
+;;   Like defn, but the resulting function name is declared as a
+;;   macro and will be used as a macro by the compiler when it is
+;;   called.
 ----
 
 ==== Discussion
@@ -68,17 +74,19 @@ You can peek under the hood at almost everything in Clojure at any
 time. The next example may be a bit mind-expanding if you're not used
 to this level of introspection at runtime:
 
-[source,shell-session]
+[source,clojure]
 ----
 user=> (source source)
-(defmacro source
-  "Prints the source code for the given symbol, if it can find it.
-  This requires that the symbol resolve to a Var defined in a
-  namespace for which the .clj is in the classpath.
-
-  Example: (source filter)"
-  [n]
-  `(println (or (source-fn '~n) (str "Source not found"))))
+;; -> nil
+;; *out*
+;; (defmacro source
+;;   "Prints the source code for the given symbol, if it can find it.
+;;   This requires that the symbol resolve to a Var defined in a
+;;   namespace for which the .clj is in the classpath.
+;; 
+;;   Example: (source filter)"
+;;   [n]
+;;   `(println (or (source-fn '~n) (str "Source not found"))))
 ----
 
 Keeping in mind that +source+ was defined in the +clojure.repl+
@@ -92,22 +100,24 @@ available.  You can get around this by namespacing the macros
 (+clojure.repl/doc+ instead of +doc+,) or, for extended use, by pass:[<literal>use</literal>]-ing the
 namespace:
 
-[source,shell-session]
+[source,clojure]
 ----
 user=> (ns foo)
 foo=> (doc +)
-CompilerException java.lang.RuntimeException: Unable to resolve symbol: doc 
-in this context, compiling:(NO_SOURCE_PATH:1:1)
+;; -> CompilerException java.lang.RuntimeException: Unable to resolve symbol: doc 
+;;    in this context, compiling:(NO_SOURCE_PATH:1:1)
 
 foo=> (use 'clojure.repl)
-nil
+;; -> nil
 
 foo=> (doc +)
- -------------------------
-clojure.core/+
-([] [x] [x y] [x y & more])
-  Returns the sum of nums. (+) returns 0. Does not auto-promote
-  longs, will throw on overflow. See also: +'
+;; -> nil
+;; *out*
+;; -------------------------
+;; clojure.core/+
+;; ([] [x] [x y] [x y & more])
+;;   Returns the sum of nums. (+) returns 0. Does not auto-promote
+;;   longs, will throw on overflow. See also: +'
 ----
 
 Exploring Clojure in this way is a great way to learn about core


### PR DESCRIPTION
Change the highlight type of the code snippets from 'shell-session' to 'clojure' and comment the output according to the section 'Conventions Used in This Book'.

The Conventions did not define how to deal with exceptions. Maybe it should be treated as some output to standard error (where an \*error\* is added above the text)? I didn't do this and just left the format same as the return values. This conforms with the other chapters and seems easy to recognize. 