### PR TITLE
Fix an ns name in 3-05_main.asciidoc

### DIFF
--- a/03_general-computing/3-05_main/3-05_main.asciidoc
+++ b/03_general-computing/3-05_main/3-05_main.asciidoc
@@ -117,7 +117,7 @@ provides a +-main+ function, like so:
     (println (foo.util/greet name))))
 ----
 
-When you invoke Clojure with +foo.core+ as the "main" namespace, it
+When you invoke Clojure with +foo+ as the "main" namespace, it
 calls the +-main+ function with the provided command-line arguments:
 
 [source,shell-session]


### PR DESCRIPTION
The name space is **foo**, not **foo.core**.