### PR TITLE
Correct the :assoc-fn in 3-07_par...ments.asciidoc

### DIFF
--- a/03_general-computing/3-07_parse-command-line-arguments.asciidoc
+++ b/03_general-computing/3-07_parse-command-line-arguments.asciidoc
@@ -108,9 +108,14 @@ Here's a complete example:
 
 [source,clojure]
 ----
+(defn assoc-max [m k v]
+  (if (contains? m k)
+    (update-in m [k] max v)
+    (assoc m k v)))
+
 (def app-specs [["-n" "--count" :default 5
                                 :parse-fn #(Integer. %)
-                                :assoc-fn max]
+                                :assoc-fn assoc-max]
                 ["-v" "--verbose" :flag true
                                   :default true]])
 


### PR DESCRIPTION
The original code doesn't work and throws the ClassCastException. :assoc-fn, as indicated by it's name, should be able to assoc the value to a map.