### PR TITLE
Highlight REPL-only code as text instead of shell-session.

### DIFF
--- a/00_frontmatter/conventions.asciidoc
+++ b/00_frontmatter/conventions.asciidoc
@@ -69,7 +69,7 @@ retain the traditional REPL style (with `user=>`). What follows is an
 example of each, a REPL-only sample and its simplified version.
 
 ._REPL-only_:
-[source,shell-session]
+[source,text]
 ----
 user=> (+ 1 2)
 3

--- a/03_general-computing/3-02_interactive-docs.asciidoc
+++ b/03_general-computing/3-02_interactive-docs.asciidoc
@@ -11,7 +11,7 @@ From a REPL, you want to read documentation for a function.((("REPL (read-eval-p
 
 Print the documentation for a function at the REPL with the +doc+ macro:
 
-[source,shell-session]
+[source,text]
 ----
 user=> (doc conj)
  -------------------------
@@ -24,7 +24,7 @@ clojure.core/conj
 
 Print the source code for a function at the REPL with the +source+ macro:
 
-[source,shell-session]
+[source,text]
 ----
 user=> (source reverse)
 (defn reverse
@@ -37,7 +37,7 @@ user=> (source reverse)
 
 Find functions with documentation matching a given regular expression using +find-doc+:
 
-[source,shell-session]
+[source,text]
 ----
 user=> (find-doc #"defmacro")
  -------------------------
@@ -68,7 +68,7 @@ You can peek under the hood at almost everything in Clojure at any
 time. The next example may be a bit mind-expanding if you're not used
 to this level of introspection at runtime:
 
-[source,shell-session]
+[source,text]
 ----
 user=> (source source)
 (defmacro source
@@ -92,7 +92,7 @@ available.  You can get around this by namespacing the macros
 (+clojure.repl/doc+ instead of +doc+,) or, for extended use, by pass:[<literal>use</literal>]-ing the
 namespace:
 
-[source,shell-session]
+[source,text]
 ----
 user=> (ns foo)
 foo=> (doc +)

--- a/03_general-computing/3-03_exploring-namespaces.asciidoc
+++ b/03_general-computing/3-03_exploring-namespaces.asciidoc
@@ -11,7 +11,7 @@ You want to know what namespaces are loaded and what public vars are available i
 
 Use +loaded-libs+ to obtain the set of currently loaded namespaces. For example, from a REPL:
 
-[source,shell-session]
+[source,text]
 ----
 user=> (pprint (loaded-libs))
 #{clojure.core.protocols clojure.instant clojure.java.browse
@@ -21,7 +21,7 @@ user=> (pprint (loaded-libs))
 
 Use +dir+ from a REPL to print the public vars in a namespace:
 
-[source,shell-session]
+[source,text]
 ----
 user=> (dir clojure.instant)
 parse-timestamp


### PR DESCRIPTION
As discussed in #445, highlight the REPL-only code snippets as text.
I think I've managed to find out all the REPL-only snippets, but those mixed with shell code and repl sessions can still be problematic. I've no idea how to deal with this and just leave them untouched. Below is an example taken from 4-15_edn-config.asciidoc:
![2015-02-27-152820_490x272_scrot](https://cloud.githubusercontent.com/assets/7708040/6408772/8ec50a62-be95-11e4-9622-57a5326c94f8.png)
