### PR TITLE
Highlight shell snippets as text instead of shell-session.

### DIFF
--- a/00_frontmatter/conventions.asciidoc
+++ b/00_frontmatter/conventions.asciidoc
@@ -96,7 +96,7 @@ Console sessions (e.g., shell commands) are denoted by monospace font,
 with lines beginning with a dollar sign (+$+) indicating a shell
 prompt. Output is printed without a leading +$+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein version
 Leiningen 2.0.0-preview10 on Java 1.6.0_29 Java HotSpot(TM) 64-Bit Server VM
@@ -132,7 +132,7 @@ user profile (_~/.lein/profiles.clj_) as follows:
 Now, inside of a project or out, you can use the *+lein try+* command
 to launch a REPL with access to whichever library you please:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-time
 #...

--- a/00_frontmatter/frontmatter.asciidoc
+++ b/00_frontmatter/frontmatter.asciidoc
@@ -216,7 +216,7 @@ The one thing you _won't_ need to manually install is Clojure itself;
 Leiningen will do this for you on an ad hoc basis. To verify your
 installation, run *+lein repl+* and check your Clojure version:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein repl
 # ...

--- a/01_primitive-data/1-11_inflecting-strings.asciidoc
+++ b/01_primitive-data/1-11_inflecting-strings.asciidoc
@@ -16,7 +16,7 @@ To follow along with this recipe, start a REPL using +lein-try+:footnote:[If
 you haven't already installed +lein-try+, follow the instructions in
 <<sec_lein_try>>.]
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try inflections
 ----

--- a/01_primitive-data/1-23_currency.asciidoc
+++ b/01_primitive-data/1-23_currency.asciidoc
@@ -14,7 +14,7 @@ representing, manipulating, and storing values in monetary units.
 To follow along with this recipe, add `[clojurewerkz/money "1.4.0"]`
 to your project's dependencies, or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clojurewerkz/money
 ----

--- a/01_primitive-data/1-27_parsing-dates.asciidoc
+++ b/01_primitive-data/1-27_parsing-dates.asciidoc
@@ -17,7 +17,7 @@ over the excellent http://bit.ly/joda-time[Joda-Time library].(((Java, date/time
 Before starting, add `[clj-time "0.6.0"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-time
 ----

--- a/01_primitive-data/1-28_formatting-dates.asciidoc
+++ b/01_primitive-data/1-28_formatting-dates.asciidoc
@@ -16,7 +16,7 @@ use https://github.com/clj-time/clj-time[+clj-time+] to format dates.(((Java, da
 Before starting, add `[clj-time "0.6.0"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-time
 ----

--- a/01_primitive-data/1-30_time-between.asciidoc
+++ b/01_primitive-data/1-30_time-between.asciidoc
@@ -16,7 +16,7 @@ library for calculating the length of a time interval.(((time zones)))(((leap ye
 Before starting, add `[clj-time "0.6.0"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-time
 ----

--- a/01_primitive-data/1-33_relative-times.asciidoc
+++ b/01_primitive-data/1-33_relative-times.asciidoc
@@ -17,7 +17,7 @@ relative dates and times.
 Before starting, add `[clj-time "0.6.0"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-time
 ----

--- a/01_primitive-data/1-34_working-with-time-zones-and-leap-years.asciidoc
+++ b/01_primitive-data/1-34_working-with-time-zones-and-leap-years.asciidoc
@@ -17,7 +17,7 @@ time zones.
 Before starting, add `[clj-time "0.6.0"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-time
 ----

--- a/02_composite-data/2-27_and_2-28_custom-data-structures/2-27_red-black-trees-part-i.asciidoc
+++ b/02_composite-data/2-27_and_2-28_custom-data-structures/2-27_red-black-trees-part-i.asciidoc
@@ -34,7 +34,7 @@ https://github.com/clojure/core.match[+core.match+] to simplify the
 implementation of an RBT. Add `[org.clojure/core.match "0.2.0"]` to your project's
 dependencies, or start a REPL with +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojure/core.match
 ----

--- a/03_general-computing/3-01_bare-bones.asciidoc
+++ b/03_general-computing/3-01_bare-bones.asciidoc
@@ -13,7 +13,7 @@ Obtain the Clojure Java archive (JAR) file by downloading and unzipping a releas
 from http://clojure.org/downloads. Using a terminal, navigate to
 where you extracted the JAR, and start a Clojure REPL:
 
-[source,shell-session]
+[source,text]
 ----
 $ java -cp "clojure-1.5.1.jar" clojure.main
 ----

--- a/03_general-computing/3-04_trying-a-library.asciidoc
+++ b/03_general-computing/3-04_trying-a-library.asciidoc
@@ -24,7 +24,7 @@ to the +:plugins+ vector of the +:user+ profile:
 Now you can experience nearly instant gratification with the library
 of your choice:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-time
 Retrieving clj-time/clj-time/0.6.0/clj-time-0.6.0.pom from clojars
@@ -50,7 +50,7 @@ released version.
 Of course, you can specify a library version if you like. Just add the
 version number after the library name:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-time 0.5.1
 #...
@@ -59,7 +59,7 @@ user=>
 
 For a quick view of usage options, invoke *+lein help try+*:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein help try
 Launch REPL with specified dependencies available.

--- a/03_general-computing/3-05_main/3-05_main.asciidoc
+++ b/03_general-computing/3-05_main/3-05_main.asciidoc
@@ -28,7 +28,7 @@ For example, given a file _my_clojure_program.clj_ with the contents:
 
 invoke the +java+ command with _my_clojure_program.clj_ as the final argument:
 
-[source,shell-session]
+[source,text]
 ----
 $ java -cp clojure.jar clojure.main my_clojure_program.clj
 Hi.
@@ -48,7 +48,7 @@ to load and run the +-main+ function, specify the desired namespace
 with the +-m+/+--main+ option and add _src_ to the classpath list (via
 +-cp+):
 
-[source,shell-session]
+[source,text]
 ----
 $ java -cp clojure.jar:src clojure.main --main com.example.my-program
 Hey!
@@ -79,7 +79,7 @@ file called _hello.clj_:
 
 Invoking this Clojure program directly will yield predictable output:
 
-[source,shell-session]
+[source,text]
 ----
 $ java -cp clojure.jar clojure.main hello.clj Alice Bob
 Hello, Alice!
@@ -120,7 +120,7 @@ provides a +-main+ function, like so:
 When you invoke Clojure with +foo+ as the "main" namespace, it
 calls the +-main+ function with the provided command-line arguments:
 
-[source,shell-session]
+[source,text]
 ----
 $ java -cp clojure.jar:src clojure.main --main foo Alice Bob
 Hello, Alice!

--- a/03_general-computing/3-06_running-programs-from-the-command-line.asciidoc
+++ b/03_general-computing/3-06_running-programs-from-the-command-line.asciidoc
@@ -12,7 +12,7 @@ You want to invoke your Clojure application from the command line.((("developmen
 In any Leiningen project, use the *+lein run+* command to invoke your
 application from the command line. To follow along with this recipe, create a new Leiningen project:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein new my-cli
 ----
@@ -44,7 +44,7 @@ _project.clj_:
 
 Now, invoke *+lein run+* to run your application:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein run
 My CLI received arguments: nil
@@ -100,7 +100,7 @@ For example, you can add a function +add-main+ to +my-cli.core+:
 then invoke it from the command line with the command *+lein run -m
 my-cli.core/add-main+*:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein run -m my-cli.core/add-main 1 2 3
 The sum is: 6

--- a/03_general-computing/3-07_parse-command-line-arguments.asciidoc
+++ b/03_general-computing/3-07_parse-command-line-arguments.asciidoc
@@ -16,7 +16,7 @@ library.
 Before starting, add `[org.clojure/tools.cli "0.2.4"]` to your project's
 dependencies, or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojure/tools.cli
 ----
@@ -199,7 +199,7 @@ Just like your application needs to use +--+ to indicate arguments to
 pass on to subsequent programs, so too must you use +--+ to indicate to
 *+lein run+* which arguments are for your program and which are for it:
 
-[source,shell-session]
+[source,text]
 ----
 # If app-specs were rigged up to a project...
 $ lein run -- -n 5 --no-verbose

--- a/03_general-computing/3-08_lein-templates.asciidoc
+++ b/03_general-computing/3-08_lein-templates.asciidoc
@@ -22,7 +22,7 @@ your own GitHub username--you'll be publishing this
 template to Clojars, and it will need a unique name. In the examples,
 we'll use `clojure-cookbook` as our GitHub username:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein new template cookbook-sample-template-clojure-cookbook
 Generating fresh 'lein new' template project.
@@ -126,7 +126,7 @@ _src/leiningen/new/<project-name>/foo.clj_ file as well:
 To test the template locally, change directories to the root of your template
 project and run:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein install
 $ lein new cookbook-sample-template-clojure-cookbook my-first-website --snapshot
@@ -155,7 +155,7 @@ templates:
 Next, visit http://clojars.org[clojars.org] to create a
 Clojars account and then deploy from the template project root:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein deploy clojars
 ----
@@ -164,7 +164,7 @@ Other users can now create projects using your template name as the
 first argument to *+lein new+*. Leiningen will automatically fetch your
 project template from Clojars:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein new cookbook-sample-template-clojure-cookbook my-second-website
 ----

--- a/03_general-computing/3-11_core-async.asciidoc
+++ b/03_general-computing/3-11_core-async.asciidoc
@@ -23,7 +23,7 @@ library to introduce and coordinate asynchronous channels.
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojure/core.async
 ----

--- a/03_general-computing/3-12_parser-with-core-match.asciidoc
+++ b/03_general-computing/3-12_parser-with-core-match.asciidoc
@@ -34,7 +34,7 @@ expression represented as maps of maps.((("Clojure", "clojure.core.match")))(((p
 Before starting, add `[org.clojure/core.match "0.2.0"]` to your
 project's dependencies, or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojure/core.match
 ----

--- a/03_general-computing/3-13_core-logic.asciidoc
+++ b/03_general-computing/3-13_core-logic.asciidoc
@@ -19,7 +19,7 @@ data.((("miniKanren Domain Specific Language")))
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojure/core.logic
 ---- 

--- a/03_general-computing/3-14_nursery-rhyme.asciidoc
+++ b/03_general-computing/3-14_nursery-rhyme.asciidoc
@@ -18,7 +18,7 @@ additional installation concerns if you are running Overtone on Linux.
 See http://bit.ly/overtone-install[the Overtone wiki] for more
 detailed installation instructions.]
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try overtone
 ----

--- a/04_local-io/4-02_read-unbuffered-keystroke.asciidoc
+++ b/04_local-io/4-02_read-unbuffered-keystroke.asciidoc
@@ -39,7 +39,7 @@ input is buffered as well by default. The JLine library provides a
 +ConsoleReader+ object whose +readCharacter+ method lets you avoid the
 input buffering. Beware, however, of testing +show-keystroke+ at the REPL:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein repl
 user=> (require '[keystroke.core :refer [show-keystroke]])
@@ -51,7 +51,7 @@ Enter a keystroke:
 In order to connect the console's input correctly to the REPL, use(((lein trampoline repl)))
 *+lein trampoline repl+* (the +<r>+ here means the user types the letter +r+):
 
-[source,shell-session]
+[source,text]
 ----
 $ lein trampoline repl
 user=> (require '[keystroke.core :refer [show-keystroke]])

--- a/04_local-io/4-03_exec-system-command.asciidoc
+++ b/04_local-io/4-03_exec-system-command.asciidoc
@@ -14,7 +14,7 @@ system.((("clj-commons-exec library")))
 
 To follow along, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojars.hozumi/clj-commons-exec "1.0.6"
 ----

--- a/04_local-io/4-07_get-files-from-directory/4-07_get-files-from-directory.asciidoc
+++ b/04_local-io/4-07_get-files-from-directory/4-07_get-files-from-directory.asciidoc
@@ -16,7 +16,7 @@ Call the built-in +file-seq+ function.
 To follow along with this recipe, create some sample files and folders
 using these commands (on Linux or Mac):
 
-[source,shell-session]
+[source,text]
 ----
 $ mkdir -p next-gen
 $ touch next-gen/picard.jpg next-gen/locutus.bmp next-gen/data.txt

--- a/04_local-io/4-08_memory-map-files.asciidoc
+++ b/04_local-io/4-08_memory-map-files.asciidoc
@@ -14,7 +14,7 @@ which wraps the memory-mapping functionality provided by Java's NIO (New I/O) li
 
 Before starting, add `[clj-mmap "1.1.2"]` to your project’s dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-mmap
 ----

--- a/04_local-io/4-11_random-access-files.asciidoc
+++ b/04_local-io/4-11_random-access-files.asciidoc
@@ -65,7 +65,7 @@ Examining the file we created using the Unix `od` program to do a hex dump from 
 command line shows that the file consists of zeros with our +1234+ at
 the end:
 
-[source,shell-session]
+[source,text]
 ----
 $ od -Ad -tx4 /tmp/longfile
 0000000          00000000        00000000        00000000        00000000

--- a/04_local-io/4-13_parallelizing-file-processing-using-iota.asciidoc
+++ b/04_local-io/4-13_parallelizing-file-processing-using-iota.asciidoc
@@ -15,7 +15,7 @@ Use the https://github.com/thebusby/iota[Iota] library in
 conjunction with the +filter+, +map+, and +fold+ functions from the
 Clojure Reducers library in the +clojure.core.reducers+ namespace.((("Clojure", "clojure.core.reducers")))(((functions, filter)))(((functions, map)))(((functions, fold))) To follow along with this recipe, add `[iota "1.1.1"]` to your project's dependencies, or start a REPL with +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try iota
 ----

--- a/04_local-io/4-15_edn-config.asciidoc
+++ b/04_local-io/4-15_edn-config.asciidoc
@@ -214,7 +214,7 @@ to one of your project's namespaces:
 Now, the configuration your application loads will depend on which
 profile your project is running in:
 
-[source,shell-session]
+[source,text]
 ----
 # "dev" is one of Leiningen's default profiles
 $ lein repl

--- a/04_local-io/4-16_edn-record.asciidoc
+++ b/04_local-io/4-16_edn-record.asciidoc
@@ -16,7 +16,7 @@ edn tagged literal values.
 Before starting, add `[com.velisco/tagged "0.3.0"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.velisco/tagged
 ----

--- a/04_local-io/4-18_read-property-file.asciidoc
+++ b/04_local-io/4-18_read-property-file.asciidoc
@@ -45,7 +45,7 @@ access to property files.(((propertea library)))
 Include the `[propertea "1.2.3"]` dependency in your _project.clj_
 file, or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try propertea 1.2.3
 ----

--- a/04_local-io/4-24_pdf/4-24_pdf.asciidoc
+++ b/04_local-io/4-24_pdf/4-24_pdf.asciidoc
@@ -17,7 +17,7 @@ Use the +clj-pdf+ library to create the report.
 Before starting, add `[clj-pdf "1.11.6"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-pdf
 ----

--- a/04_local-io/4-25_seesaw/4-25_making-a-window.asciidoc
+++ b/04_local-io/4-25_seesaw/4-25_making-a-window.asciidoc
@@ -15,7 +15,7 @@ for creating GUIs with Clojure.(((Java, Swing library)))(((Seesaw library)))(((S
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try seesaw
 ----

--- a/05_network-io/5-01_making-an-http-request.asciidoc
+++ b/05_network-io/5-01_making-an-http-request.asciidoc
@@ -24,7 +24,7 @@ circumstances, or to get specific details about the response.(((clj-http library
 To follow along, add `[clj-http "0.7.7"]` to your project's
 dependencies, or use +lein-try+ to start a REPL:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-http
 ----

--- a/05_network-io/5-02_async-http-requests.asciidoc
+++ b/05_network-io/5-02_async-http-requests.asciidoc
@@ -15,7 +15,7 @@ HTTP client/server library.((("HTTP (Hypertext Transfer Protocol)", "asynchronou
 Before starting, add `[http-kit "2.1.12"]` to your project's
 dependencies, or follow along in a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try http-kit
 ----

--- a/05_network-io/5-04_rss.asciidoc
+++ b/05_network-io/5-04_rss.asciidoc
@@ -13,7 +13,7 @@ Use the +feedparser-clj+ library to parse RSS data.(((feedparser-clj library)))
 Before starting, add `[org.clojars.scsibug/feedparser-clj "0.4.0"]` to
 your project's dependencies, or follow along in a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojars.scsibug/feedparser-clj
 ----

--- a/05_network-io/5-05_sending-email.asciidoc
+++ b/05_network-io/5-05_sending-email.asciidoc
@@ -13,7 +13,7 @@ messages.(((postal wrapper)))(((Java, JavaMail package)))(((functions, postal.co
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.draines/postal
 ----

--- a/05_network-io/5-06_queueing-with-rabbitmq.asciidoc
+++ b/05_network-io/5-06_queueing-with-rabbitmq.asciidoc
@@ -15,7 +15,7 @@ RabbitMQ client, to communicate with RabbitMQ.(((networking/web services, commun
 Before starting, add `[com.novemberain/langohr "1.6.0"]` to your
 project's dependencies, or follow along in a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.novemberain/langohr
 ----
@@ -26,7 +26,7 @@ http://bit.ly/rmq-download[installed and running].
 Once installed, start a standalone RabbitMQ server with the command
 *+rabbitmq-server+*:
 
-[source,shell-session]
+[source,text]
 ----
 $ rabbitmq-server
 ----

--- a/05_network-io/5-07_communicating-with-mqtt.asciidoc
+++ b/05_network-io/5-07_communicating-with-mqtt.asciidoc
@@ -19,7 +19,7 @@ need a functional Internet connection on your machine).
 
 To follow along with this recipe, launch a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clojurewerkz/machine_head
 ----

--- a/05_network-io/5-08_zmq-async.asciidoc
+++ b/05_network-io/5-08_zmq-async.asciidoc
@@ -21,14 +21,14 @@ ZeroMQ 3.2 installed.
 If you're on a Mac and have the http://brew.sh[Homebrew] package
 manager installed, use this command to install it:
 
-[source,shell-session]
+[source,text]
 ----
 $ brew install zeromq
 ----
 
 Or, if you are on Ubuntu:
 
-[source,shell-session]
+[source,text]
 ----
 $ apt-get install libzmq3
 ----
@@ -39,7 +39,7 @@ downloads page].
 Before starting, add `[com.keminglabs/zmq-async "0.1.0"]` to your
 project's dependencies, or follow along in a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.keminglabs/zmq-async
 ----

--- a/05_network-io/5-10_tcp-server.asciidoc
+++ b/05_network-io/5-10_tcp-server.asciidoc
@@ -77,7 +77,7 @@ To connect to the server you can use a _telnet_ client, which is
 installed by default on nearly every operating system. To use it, open
 up a command-line window:
 
-[source,shell-session]
+[source,text]
 ----
 $ telnet localhost 8888
 Trying ::1...
@@ -88,7 +88,7 @@ Escape character is '^]'.
 At this point you can type anything you like (in the following example, the input is "Hello, World!"). When you finish, make
 sure you type Enter or Return to send a newline character:
 
-[source,shell-session]
+[source,text]
 ----
 $ telnet localhost 8888
 Trying ::1...

--- a/06_databases/6-01_connecting-to-an-SQL-database.asciidoc
+++ b/06_databases/6-01_connecting-to-an-SQL-database.asciidoc
@@ -23,7 +23,7 @@ wiki].]
 After you have PostgreSQL running (presumably on _localhost:5432_), run the following
 command to create a database for this recipe:
 
-[source,shell-session]
+[source,text]
 ----
 # On Mac:
 $ /Applications/Postgres93.app/Contents/MacOS/bin/createdb cookbook_experiments
@@ -38,7 +38,7 @@ of your choice. If you're following along with this sample, use
 `[org.postgresql/postgresql "9.2-1003-jdbc4"]`. To start a REPL using
 +lein-try+, enter the following Leiningen command:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojure/java.jdbc "0.3.0" \
            java-jdbc/dsl "0.1.0" \

--- a/06_databases/6-02_SQL-database-connection-pooling.asciidoc
+++ b/06_databases/6-02_SQL-database-connection-pooling.asciidoc
@@ -26,7 +26,7 @@ wiki].]
 After you have PostgreSQL running (presumably on _localhost:5432_), run the following
 command to create a database for this recipe:
 
-[source,shell-session]
+[source,text]
 ----
 # On Mac:
 $ /Applications/Postgres93.app/Contents/MacOS/bin/createdb cookbook_experiments
@@ -40,7 +40,7 @@ Before starting, add the BoneCP dependency (`[com.jolbox/bonecp
 RDBMS, to your project's dependencies. You'll also need a valid SLF4J
 logger. Alternatively, you can follow along in a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.jolbox/bonecp "0.8.0.RELEASE" \
            org.clojure/java.jdbc "0.3.0" \

--- a/06_databases/6-03_manipulating-an-SQL-database.asciidoc
+++ b/06_databases/6-03_manipulating-an-SQL-database.asciidoc
@@ -23,7 +23,7 @@ wiki].]
 After you have PostgreSQL running (presumably on _localhost:5432_), run the following
 command to create a database for this recipe:
 
-[source,shell-session]
+[source,text]
 ----
 # On Mac:
 $ /Applications/Postgres93.app/Contents/MacOS/bin/createdb cookbook_experiments
@@ -39,7 +39,7 @@ along with this sample, use `[org.postgresql/postgresql
 "9.2-1003-jdbc4"]`. To start a REPL using +lein-try+, enter the
 following Leiningen command:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojure/java.jdbc "0.3.0" \
            java-jdbc/dsl "0.1.0" \

--- a/06_databases/6-04_korma.asciidoc
+++ b/06_databases/6-04_korma.asciidoc
@@ -17,7 +17,7 @@ Before starting, add `[korma "0.3.0-RC6"]` and
 `[org.postgresql/postgresql "9.2-1002-jdbc4"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try korma org.postgresql/postgresql
 ----
@@ -34,7 +34,7 @@ wiki].]
 After you have PostgreSQL running (presumably on _localhost:5432_), run the following
 command to create a database for this recipe:
 
-[source,shell-session]
+[source,text]
 ----
 # On Mac:
 $ /Applications/Postgres.app/Contents/MacOS/bin/createdb learn_korma

--- a/06_databases/6-06_indexing-with-elasticsearch.asciidoc
+++ b/06_databases/6-06_indexing-with-elasticsearch.asciidoc
@@ -26,7 +26,7 @@ discussion section.
 
 To follow along with this recipe, add `[clojurewerkz/elastisch "1.2.0"]` to your project's dependencies, or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clojurewerkz/elastisch
 ----

--- a/06_databases/6-07_cassandra-with-cassaforte.asciidoc
+++ b/06_databases/6-07_cassandra-with-cassaforte.asciidoc
@@ -16,7 +16,7 @@ install Cassandra on the http://wiki.apache.org/cassandra/GettingStarted[Getting
 
 To follow along with this recipe, add `[clojurewerkz/cassaforte "1.1.0"]` to your project's dependencies, or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clojurewerkz/cassaforte
 ----

--- a/06_databases/6-08_mongo.asciidoc
+++ b/06_databases/6-08_mongo.asciidoc
@@ -19,7 +19,7 @@ instructions on how to install MongoDB on your local system.
 
 When you're ready to write a Clojure MongoDB client, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.novemberain/monger
 ----

--- a/06_databases/6-09_redis.asciidoc
+++ b/06_databases/6-09_redis.asciidoc
@@ -18,7 +18,7 @@ Tech GitHub Redis project].
 
 To follow along with this recipe, add `[com.taoensso/carmine "2.2.0"]` to your project's dependencies, or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.taoensso/carmine
 ----

--- a/06_databases/6-10_connect-to-datomic.asciidoc
+++ b/06_databases/6-10_connect-to-datomic.asciidoc
@@ -13,7 +13,7 @@ You need to connect to a Datomic database.((("databases", "Datomic", id="ix_DBdt
 Before starting, add `[com.datomic/datomic-free "0.8.4218"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.datomic/datomic-free
 ----

--- a/07_webapps/7-11_enlive.asciidoc
+++ b/07_webapps/7-11_enlive.asciidoc
@@ -18,7 +18,7 @@ for replacement or duplication based on incoming data.
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try enlive
 ----

--- a/07_webapps/7-12_templating-with-selmer.asciidoc
+++ b/07_webapps/7-12_templating-with-selmer.asciidoc
@@ -16,7 +16,7 @@ dynamic content.
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try selmer
 ----

--- a/07_webapps/7-13_templating-with-hiccup.asciidoc
+++ b/07_webapps/7-13_templating-with-hiccup.asciidoc
@@ -15,7 +15,7 @@ made up of regular Clojure data structures.
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try hiccup
 ----

--- a/07_webapps/7-14_markdown.asciidoc
+++ b/07_webapps/7-14_markdown.asciidoc
@@ -13,7 +13,7 @@ Use the https://github.com/yogthos/markdown-clj[+markdown-clj+ library] to rende
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try markdown-clj
 ----

--- a/07_webapps/7-15_luminus.asciidoc
+++ b/07_webapps/7-15_luminus.asciidoc
@@ -18,7 +18,7 @@ Use the Luminus Leiningen template when creating a new project.
 
 At the command line, type:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein new luminus myapp
 ----
@@ -30,7 +30,7 @@ deployed on an application server.
 
 You can start the application in development mode by running:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein ring server
 ----
@@ -50,7 +50,7 @@ When creating the application, you can add functionality by specifying profiles 
 the relevant stubs. The following are some examples of initializing the
 application with default configurations for different databases:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein new luminus app1 +h2
 

--- a/08_deployment-and-distribution/8-02_creating-executable-jar/8-02_creating-executable-jar.asciidoc
+++ b/08_deployment-and-distribution/8-02_creating-executable-jar/8-02_creating-executable-jar.asciidoc
@@ -15,7 +15,7 @@ dependencies.
 
 To follow along with this recipe, create a new Leiningen project:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein new foo
 ----
@@ -54,7 +54,7 @@ To finish making the project executable, add a +-main+ function and
 Run the application using the *+lein run+* command to verify it is
 functioning correctly:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein run 1 2 3
 ----
@@ -62,7 +62,7 @@ $ lein run 1 2 3
 To package the application with all of its dependencies included,
 invoke *+lein uberjar+*:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein uberjar
 Created /tmp/foo/target/uberjar/foo-0.1.0-SNAPSHOT.jar
@@ -72,7 +72,7 @@ Created /tmp/foo/target/foo-0.1.0-SNAPSHOT-standalone.jar
 Execute the generated _target/foo-0.1.0-SNAPSHOT-standalone.jar_ file by
 passing it as the +-jar+ option to the +java+ executable:
 
-[source,shell-session]
+[source,text]
 ----
 $ java -jar target/foo-1.0.0-standalone.jar 1 2 3
 Executed with the following args:  1 2 3
@@ -115,7 +115,7 @@ file--you'll need to BYOC.footnote:[Bring your own Clojure!]
 By invoking the command *+lein jar+* in the +foo+ project, you'll
 generate _target/foo-0.1.0-SNAPSHOT.jar_:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein jar
 Created /tmp/foo/target/jar/target/foo-0.1.0-SNAPSHOT.jar
@@ -125,7 +125,7 @@ Listing the contents of the JAR file using the *+unzip+* command,footnote:[Avail
 little is packaged--just a Maven _.pom_ file, generated JVM class files,
 and the project's miscellany:
 
-[source,shell-session]
+[source,text]
 ----
 $ unzip -l target/foo-0.1.0-SNAPSHOT.jar
 Archive:  target/foo-0.1.0-SNAPSHOT.jar
@@ -175,7 +175,7 @@ classpath (via the +-cp+ option):
 <?hard-pagebreak?>
 ++++
 
-[source,shell-session]
+[source,text]
 ----
 # Download Clojure
 $ wget \

--- a/08_deployment-and-distribution/8-03_war-file.asciidoc
+++ b/08_deployment-and-distribution/8-03_war-file.asciidoc
@@ -50,7 +50,7 @@ Ring handler function.
 +lein-ring+ provides a handy way to run your application locally, for
 development and testing. At the command line, simply type:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein ring server
 ----
@@ -64,12 +64,12 @@ Once you think the application is running correctly, you can build a
 WAR file using the *+lein ring war+* or *+lein ring uberwar+*
 commands. Both take the name of the WAR file to emit:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein ring war warsample.war
 ----
 
-[source,shell-session]
+[source,text]
 ----
 $ lein ring uberwar warsample-with-deps.war
 ----

--- a/08_deployment-and-distribution/8-04_daemons.asciidoc
+++ b/08_deployment-and-distribution/8-04_daemons.asciidoc
@@ -84,7 +84,7 @@ touching the +Daemon+ interface:
 Package all of the necessary dependencies and generated classes by
 invoking the Leiningen +uberjar+ command:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein uberjar
 Compiling my-daemon.core
@@ -94,7 +94,7 @@ Created /tmp/my-daemon/target/my-daemon-0.1.0-SNAPSHOT-standalone.jar
 
 Before proceeding, test your application by running it with +java+:
 
-[source,shell-session]
+[source,text]
 ----
 $ java -jar target/my-daemon-0.1.0-SNAPSHOT-standalone.jar
 tick
@@ -114,7 +114,7 @@ path of your Java home directory, the uberjar, the output log file, and the
 namespace where your +Daemon+ implementation resides:footnote:[Don't
 worry, we'll capture all this in a shell script soon.]
 
-[source,shell-session]
+[source,text]
 ----
 $ sudo jsvc -java-home "$JAVA_HOME" \
             -cp "$(pwd)/target/my-daemon-0.1.0-SNAPSHOT-standalone.jar" \
@@ -262,7 +262,7 @@ respectively. Any arguments following the name of the class to invoke
 will be passed into +-init+ as a +DaemonContext+.
 
 .A more complete example:
-[source,shell-session]
+[source,text]
 ----
 $ sudo jsvc -java-home "$JAVA_HOME" \
             -cp "$(pwd)/target/my-daemon-0.1.0-SNAPSHOT-standalone.jar" \

--- a/08_deployment-and-distribution/8-06_primitive-arrays.asciidoc
+++ b/08_deployment-and-distribution/8-06_primitive-arrays.asciidoc
@@ -19,7 +19,7 @@ quick and easy way to manipulate primitive arrays of +double+, +long+, +float+, 
 Before starting, add `[prismatic/hiphip "0.1.0"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try prismatic/hiphip
 ----

--- a/08_deployment-and-distribution/8-07_profiling-with-timbre.asciidoc
+++ b/08_deployment-and-distribution/8-07_profiling-with-timbre.asciidoc
@@ -17,7 +17,7 @@ in production.
 Before starting, add `[com.taoensso/timbre "2.6.3"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.taoensso/timbre
 ----
@@ -51,7 +51,7 @@ higher-order function +f+ that takes zero or one argument.
 
 Timbre outputs rich profiling information in a convenient table:
 
-[source,shell-session]
+[source,text]
 ----
 2013-Aug-25 ... Profiling :taoensso.timbre.profiling/Bench-f
                         Name  Calls    Min    Max   MAD   Mean Time%   Time

--- a/08_deployment-and-distribution/8-08_logging-with-timbre.asciidoc
+++ b/08_deployment-and-distribution/8-08_logging-with-timbre.asciidoc
@@ -14,7 +14,7 @@ logger and add logging messages to your code.
 Before starting, add `[com.taoensso/timbre "2.7.1"]` to your project's
 dependencies or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try com.taoensso/timbre
 ----

--- a/08_deployment-and-distribution/8-09_releasing-a-library.asciidoc
+++ b/08_deployment-and-distribution/8-09_releasing-a-library.asciidoc
@@ -24,7 +24,7 @@ my-first-project-<firstname>-<lastname>+*, replacing +<firstname>+ and
 You can now use the command *+lein deploy clojars+* to release your
 library to Clojars:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein deploy clojars
 WARNING: please set :description in project.clj.

--- a/09_distributed-computation/9-01_stream-processing.asciidoc
+++ b/09_distributed-computation/9-01_stream-processing.asciidoc
@@ -30,7 +30,7 @@ easily extended to solve real-world problems.(((Storm, project creation/setup)))
 
 First, create a new http://storm.incubator.apache.org/[Storm project] using its Leiningen template:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein new cookbook-storm-project feeds
 ----
@@ -38,7 +38,7 @@ $ lein new cookbook-storm-project feeds
 In the project directory, run the default Storm topology (which the
 +lein+ template has generated for you):
 
-[source,shell-session]
+[source,text]
 ----
 $ cd feeds
 $ lein run -m feeds.topology/run!
@@ -158,7 +158,7 @@ You'll also need to update the +:require+ statement in that file:
 Run the topology again. Feeds will be printed to the console by the
 final bolts in the topology:
 
-[source,shell-session]
+[source,text]
 $ lein run -m feeds.topology/run!
 
 ==== Discussion
@@ -504,7 +504,7 @@ compiled to look like a normal Java class file. You can upload this JAR
 to the machine running Storm's _Nimbus_ daemon and submit it for
 execution using the +storm+ command:
 
-[source,shell-session]
+[source,text]
 ----
 $ storm jar path/to/thejariuploaded.jar feeds.TopologySubmitter "workers" 5
 ----

--- a/09_distributed-computation/9-02_etl.asciidoc
+++ b/09_distributed-computation/9-02_etl.asciidoc
@@ -30,7 +30,7 @@ locally for small jobs or on a Hadoop cluster for larger jobs.((("ETL (Extract T
 
 To follow along with this recipe, create a new Leiningen project:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein new cookbook
 ----
@@ -99,7 +99,7 @@ repository.
 To retrieve a copy of the working project, clone the project from
 GitHub and check out the +etl-sample+ branch:
 
-[source,shell-session]
+[source,text]
 ----
 $ git clone https://github.com/clojure-cookbook/cascalog-samples.git
 $ cd cascalog-samples
@@ -110,7 +110,7 @@ $ git checkout etl-sample
 You can now execute the job locally with *+lein run+*, providing an
 input and output file:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein run -m cookbook.etl.Main samples/books/books.json samples/books/output
 

--- a/09_distributed-computation/9-03_aggregating-large-files.asciidoc
+++ b/09_distributed-computation/9-03_aggregating-large-files.asciidoc
@@ -41,7 +41,7 @@ GitHub repository] and check out the +aggregation-begin+ branch. This
 will give you a basic Cascalog project as created in
 <<sec_cascalog_etl>>:
 
-[source,shell-session]
+[source,text]
 ----
 $ git clone https://github.com/clojure-cookbook/cascalog-samples.git
 $ cd cascalog-samples
@@ -117,7 +117,7 @@ repository.
 
 Check out that branch to retrieve a full working copy with sample data:
 
-[source,shell-session]
+[source,text]
 ----
 $ git checkout aggregation-complete
 ----
@@ -125,7 +125,7 @@ $ git checkout aggregation-complete
 
 You can now execute the job locally:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein run -m cookbook.aggregation.Main \
   samples/posts/posts.csv samples/posts/output

--- a/09_distributed-computation/9-04_testing.asciidoc
+++ b/09_distributed-computation/9-04_testing.asciidoc
@@ -73,7 +73,7 @@ repository].
 
 Check out that branch to retrieve a full working copy with sample data:
 
-[source,shell-session]
+[source,text]
 ----
 $ git checkout testing-complete
 ----
@@ -81,7 +81,7 @@ $ git checkout testing-complete
 
 Finally, run the tests with *+lein midje+*:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein midje
 2013-11-09 12:19:27.844 java[3620:1703] Unable to load realm info from

--- a/09_distributed-computation/9-06_explain/9-06_explain.asciidoc
+++ b/09_distributed-computation/9-06_explain/9-06_explain.asciidoc
@@ -23,7 +23,7 @@ Next, you'll want to view the DOT file. There are many ways to do that,
 but the easiest is probably by using +dot+, one of the Graphviz tools,
 to convert a DOT file to a PNG or GIF:
 
-[source,shell-session]
+[source,text]
 ----
 $ dot -Tpng -oslow-query.png slow-query.dot
 ----

--- a/09_distributed-computation/9-07_emr/9-07_emr.asciidoc
+++ b/09_distributed-computation/9-07_emr/9-07_emr.asciidoc
@@ -18,7 +18,7 @@ of recipes in this chapter that can help you create a complete
 Cascalog job. If you don't have your own, you can clone
 <<sec_cascalog_etl>>:
 
-[source,shell-session]
+[source,text]
 ----
 $ git clone https://github.com/clojure-cookbook/cascalog-samples.git
 $ cd cascalog-samples
@@ -27,7 +27,7 @@ $ git checkout etl-sample
 
 Once you have a Cascalog project, package it into an uberjar:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein compile
 $ lein uberjar

--- a/10_testing/10-01_unit-testing.asciidoc
+++ b/10_testing/10-01_unit-testing.asciidoc
@@ -206,7 +206,7 @@ _<project-root>/test_ folder, and you can run your project's tests with
 +lein test+ at the command line. Without any additional arguments, the
 +lein test+ command will execute all of the tests in a project:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein test
 
@@ -220,7 +220,7 @@ Ran 10 tests containing 20 assertions.
 To limit the scope of tests Leiningen runs, use the +:only+ option,
 followed by a fully qualified namespace or function name:
 
-[source,shell-session]
+[source,text]
 ----
 # To run an entire namespace
 $ lein test :only com.example.core-test

--- a/10_testing/10-02_midje.asciidoc
+++ b/10_testing/10-02_midje.asciidoc
@@ -15,7 +15,7 @@ provides ways to mock functions and return fakes.
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try midje clj-http
 ----

--- a/10_testing/10-03_generative.asciidoc
+++ b/10_testing/10-03_generative.asciidoc
@@ -15,7 +15,7 @@ test it across randomly generated values.
 
 To follow along with this recipe, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojure/test.generative "0.5.0"
 ----
@@ -213,7 +213,7 @@ _tests/generative_ directory inside a Leiningen project, you could
 execute tests by running the following at the shell, from your
 project's root directory:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein run -m clojure.test.generative.runner tests/generative
 ----

--- a/10_testing/10-04_simplecheck.asciidoc
+++ b/10_testing/10-04_simplecheck.asciidoc
@@ -18,7 +18,7 @@ _local_ minimum, not the _global_ minimum.]
 
 To follow along with this recipe, add `[reiddraper/simple-check "0.5.3"]` to your project's dependencies, or start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try reiddraper/simple-check
 ----

--- a/10_testing/10-05_browser-testing.asciidoc
+++ b/10_testing/10-05_browser-testing.asciidoc
@@ -14,7 +14,7 @@ actual browser environments.
 
 To follow along with this recipe, create a new Leiningen project:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein new browser-testing
 Generating a project called browser-testing based on the 'default' template.
@@ -70,7 +70,7 @@ _test/browser_testing/core_test.clj_, overwriting its content:
 ====
 A complete version of this repository is available https://github.com/clojure-cookbook/browser-testing[on GitHub]. Check out a copy locally to catch up:
 
-[source,shell-session]
+[source,text]
 ----
 $ git clone https://github.com/clojure-cookbook/browser-testing
 $ cd browser-testing
@@ -79,7 +79,7 @@ $ cd browser-testing
 
 Run the tests on the command line:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein test :browser
 
@@ -131,7 +131,7 @@ and the http://bit.ly/clj-webdriver-wiki[+clj-webdriver+ wiki].
 Before you dive into testing, you can experiment with +clj-webdriver+ at
 a REPL. Start up a REPL with +clj-webdriver+ using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try clj-webdriver "0.6.0"
 ----
@@ -253,7 +253,7 @@ selector argument to +lein test+:
 <?hard-pagebreak?>
 ++++
 
-[source,shell-session]
+[source,text]
 ----
 $ lein test :browser
 

--- a/10_testing/10-06_tracing.asciidoc
+++ b/10_testing/10-06_tracing.asciidoc
@@ -18,7 +18,7 @@ project's dependencies under the +:development+ profile (in the vector
 at the `:profiles {:dev {:dependencies [...]}}` path instead of the
 `:dependencies [...]` path). Alternatively, start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ lein try org.clojure/tools.trace
 ----

--- a/10_testing/10-07_avoid-null-pointer.asciidoc
+++ b/10_testing/10-07_avoid-null-pointer.asciidoc
@@ -16,7 +16,7 @@ check a namespace for misuses of `nil`.
 To follow along with this recipe, create a file _core_typed_samples.clj_
 and start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ touch core_typed_samples.clj
 $ lein try org.clojure/core.typed

--- a/10_testing/10-08_verify-java-interop.asciidoc
+++ b/10_testing/10-08_verify-java-interop.asciidoc
@@ -19,7 +19,7 @@ To type-check Java interop calls, use +core.typed+.
 To follow along with this recipe, create a file _core_typed_samples.clj_
 and start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ touch core_typed_samples.clj
 $ lein try org.clojure/core.typed
@@ -81,7 +81,7 @@ Add a type hint to call the http://bit.ly/javadoc-file-constructor[`public File(
 
 Checking again, +core.typed+ is satisfied:
 
-[source,shell-session]
+[source,text]
 ----
 user=> (t/check-ns 'core-typed-samples)
 # ...

--- a/10_testing/10-09_hof-typed.asciidoc
+++ b/10_testing/10-09_hof-typed.asciidoc
@@ -16,7 +16,7 @@ Use +core.typed+ to type-check higher-order functions.
 To follow along with this recipe, create a file _core_typed_samples.clj_
 and start a REPL using +lein-try+:
 
-[source,shell-session]
+[source,text]
 ----
 $ touch core_typed_samples.clj
 $ lein try org.clojure/core.typed
@@ -113,7 +113,7 @@ only for checking your code, but also for investigating built-in functions.
 Invoking +cf+ on any of Clojure's higher-order functions reveals their
 type signatures:
 
-[source,shell-session]
+[source,text]
 -----
 user=> (t/cf iterate)
 (All [x] 
@@ -127,7 +127,7 @@ and returns an +x+, and takes an +x+, and returns a lazy sequence of +x+."
 The +cf+ macro can also detect when the wrong number of arguments are
 being passed to a function returned by another function:
 
-[source,shell-session]
+[source,text]
 -----
 user=> (t/cf (fn [] ((hash-of? + number?))))
 Type Error (user:1:15) Type mismatch:


### PR DESCRIPTION
As mentioned in #449, shell syntax isn't rendered at all in the O'Reilly versions. 
*Shell-session* highlighting seems to serve a better purpose when the code is a pure shell script. When mixed with the outputs and repl sessions, it's better to use *text*. 
While there's advantage to use *shell-session* in certain contexts, I think it's better to use *text* for all for the sake of consistency.

