### PR TITLE
Update storm homepage links.

### DIFF
--- a/09_distributed-computation/9-00_introduction.asciidoc
+++ b/09_distributed-computation/9-00_introduction.asciidoc
@@ -14,7 +14,7 @@ we'll be covering http://cascalog.org/[Cascalog], a data-processing
 library built on top of http://hadoop.apache.org/[Hadoop], which is an open source MapReduce
 implementation.((("Amazon’s Elastic MapReduce (EMR)", see="Elastic MapReduce (EMR)")))((("MapReduce", see="Elastic MapReduce (EMR)")))((("cloud computing", see="distributed computation")))((("Elastic MapReduce (EMR)", "basics of")))(((distributed computation, Elastic MapReduce)))
 
-We'll also briefly cover http://storm-project.net/[Storm], a
+We'll also briefly cover http://storm.apache.org/[Storm], a
 real-time stream-processing library in use at several tech giants
 such as Twitter, Groupon, and Yahoo!.
 

--- a/09_distributed-computation/9-01_stream-processing.asciidoc
+++ b/09_distributed-computation/9-01_stream-processing.asciidoc
@@ -22,13 +22,13 @@ they should provide high-level abstractions that help you organize and
 grow the complexity of your stream-processing logic to accommodate new
 features and a complex world.(((userbases)))(((realtime computation systems)))(((activity stream processing)))
 
-Clojure offers just such a tool in http://storm-project.net/[Storm], a
+Clojure offers just such a tool in http://storm.apache.org/[Storm], a
 distributed real-time computation system that aims to be for real-time
 computation what Hadoop is for batch computation. In this section,
 you'll build a simple activity stream processing system that can be
 easily extended to solve real-world problems.(((Storm, project creation/setup)))
 
-First, create a new http://storm.incubator.apache.org/[Storm project] using its Leiningen template:
+First, create a new http://storm.apache.org/[Storm project] using its Leiningen template:
 
 [source,shell-session]
 ----
@@ -544,7 +544,7 @@ code and happy programmers.
 
 ==== See Also
 
-* http://storm-project.net/[Storm's website]
+* http://storm.apache.org/[Storm's website]
 * The Storm http://bit.ly/storm-template[project template]
 * https://github.com/nathanmarz/storm-deploy[+storm-deploy+], a tool for easy Storm deployment
 * https://github.com/utahstreetlabs/risingtide[Rising Tide], the feed


### PR DESCRIPTION
Both http://storm-project.net and http://storm.incubator.apache.org now redirect to http://storm.apache.org.