### PR TITLE
Remove unneccessary call to partial in 4.13

### DIFF
--- a/04_local-io/4-13_parallelizing-file-processing-using-iota.asciidoc
+++ b/04_local-io/4-13_parallelizing-file-processing-using-iota.asciidoc
@@ -33,7 +33,7 @@ To count the words in a very large file, for example:
 (defn count-map
   "Returns a map of words to occurence count in the given string"
   [s]
-  (reduce (fn [m w] (update-in m [w] (fnil (partial inc) 0)))
+  (reduce (fn [m w] (update-in m [w] (fnil inc 0)))
           {}
           (str/split s #" ")))
 


### PR DESCRIPTION
As **(partial inc)** equals to **inc**, there's no need to use the former.