### PR TITLE
Fix a wrong ns in 4.22

### DIFF
--- a/04_local-io/4-22_read-write-xml.asciidoc
+++ b/04_local-io/4-22_read-write-xml.asciidoc
@@ -24,7 +24,7 @@ use +clojure.xml/parse+:
 
 [source,clojure]
 ----
-(require '[clojure.xml :as xml])
+(require 'clojure.xml)
 (clojure.xml/parse (clojure.java.io/file "simple.xml"))
 ;; -> {:tag :simple, :attrs nil, :content [
 ;;    {:tag :item, :attrs {:id "1"}, :content ["First"]} 
@@ -36,7 +36,7 @@ function from the +clojure.core+ namespace:
 
 [source,clojure]
 ----
-(xml/xml-seq (clojure.xml/parse (clojure.java.io/file "simple.xml")))
+(xml-seq (clojure.xml/parse (clojure.java.io/file "simple.xml")))
 ----
 
 +xml-seq+ returns a tree sequence of nodes; that is, a sequence of


### PR DESCRIPTION
**xml-seq** is in the **clojure.core** ns, not the **clojure.xml** ns.
As this is the only place where the alias of the ns is used, I removed the **:as** option in the **require**  call.  