### PR TITLE
Change reify comment to match code

### DIFF
--- a/03_general-computing/3-09_polymorphism-with-protocols.asciidoc
+++ b/03_general-computing/3-09_polymorphism-with-protocols.asciidoc
@@ -267,7 +267,7 @@ protocol's methods:
 (perimeter (->Square 1))
 ;; -> 4
 
-;; Calculate the area of a parallelogram without defining a record
+;; Calculate the area of a rectangle without defining a record
 (area
   (let [b 2
         h 3]


### PR DESCRIPTION
The code describes math functions consistent with a rectangle, and not those of a parallelogram. To make the code match a parallelogram we would need a third variable representing the side length. This change is much smaller.