### PR TITLE
Update 6-01_connecting-to-an-SQL-database.asciidoc

### DIFF
--- a/06_databases/6-01_connecting-to-an-SQL-database.asciidoc
+++ b/06_databases/6-01_connecting-to-an-SQL-database.asciidoc
@@ -162,7 +162,7 @@ of everyday database access needs.
 ==== See Also
 
 * See <<sec_db_connecting_with_a_connection_pooling>>, to learn about
-  pooling connections to an SQL database with +c3p0+ and
+  pooling connections to an SQL database with +BoneCP+ and
   +clojure.java.jdbc+.
 * See <<sec_db_manipulating_a_sql_database>>, to learn about using
   +clojure.java.jdbc+ to interact with an SQL database.


### PR DESCRIPTION
The item mentions c3p0, but the recipe 6.2 actually uses BoneCP.