### PR TITLE
Fix an ArityException in 6.04

### DIFF
--- a/06_databases/6-04_korma.asciidoc
+++ b/06_databases/6-04_korma.asciidoc
@@ -89,7 +89,7 @@ must match the names of the columns in the database:
 [source,clojure]
 ----
 (insert posts
-        (values nil {:title "First post" :content "blah blah blah"}))
+        (values {:title "First post" :content "blah blah blah"}))
 ----
 
 To retrieve values from the database, query using +select+. Successful


### PR DESCRIPTION
The **korma.core/values** function accepts one less argument when surrounded by the **korma.core/insert** function because the latter supplies one.