### PR TITLE
Several fixes in 6.06

### DIFF
--- a/06_databases/6-06_indexing-with-elasticsearch.asciidoc
+++ b/06_databases/6-06_indexing-with-elasticsearch.asciidoc
@@ -148,7 +148,7 @@ cause a document ID to be generated automatically:
 
 [source,clojure]
 ----
-(esr/put "test4" "person" "happyjoe" doc1)
+(esd/put "test4" "person" "happyjoe" doc1)
 ----
 
 ==== Discussion

--- a/06_databases/6-06_indexing-with-elasticsearch.asciidoc
+++ b/06_databases/6-06_indexing-with-elasticsearch.asciidoc
@@ -69,7 +69,7 @@ To create an index, use the +clojurewerkz.elastisch.rest.index/create+ function:
 (esi/create "test1")
 
 ;; Create an index with custom settings
-(esi/create "test2" :settings {"number_of_shards" 1}))
+(esi/create "test2" :settings {"number_of_shards" 1})
 ----
 
 A full explanation of the available indexing settings is outside the
@@ -101,7 +101,7 @@ an index is created using the +:mapping+ option:
                                               :term_vector
                                               "with_positions_offsets"}}}})
 
-(esi/create "test3" :mappings mapping-types)))
+(esi/create "test3" :mappings mapping-types)
 ----
 
 ===== Indexing documents

--- a/06_databases/6-06_indexing-with-elasticsearch.asciidoc
+++ b/06_databases/6-06_indexing-with-elasticsearch.asciidoc
@@ -130,7 +130,7 @@ cause a document ID to be generated automatically:
 
 (esi/create "test4" :mappings mapping-types)
 
-(def doc {:username "happyjoe"
+(def doc1 {:username "happyjoe"
           :first-name "Joe"
           :last-name "Smith"
           :age 30
@@ -139,7 +139,7 @@ cause a document ID to be generated automatically:
           :biography "N/A"})
 
 
-(esd/create "test4" "person" doc)
+(esd/create "test4" "person" doc1)
 ;; => {:created true, :_index "test4", :_type "person",
 ;;     :_id "2vr8sP-LTRWhSKOxyWOi_Q", :_version 1}
 ----
@@ -148,7 +148,7 @@ cause a document ID to be generated automatically:
 
 [source,clojure]
 ----
-(esr/put "test4" "person" "happyjoe" doc)
+(esr/put "test4" "person" "happyjoe" doc1)
 ----
 
 ==== Discussion

--- a/06_databases/6-06_indexing-with-elasticsearch.asciidoc
+++ b/06_databases/6-06_indexing-with-elasticsearch.asciidoc
@@ -140,7 +140,7 @@ cause a document ID to be generated automatically:
 
 
 (esd/create "test4" "person" doc)
-;; => {:ok true, :_index people, :_type person,
+;; => {:created true, :_index "test4", :_type "person",
 ;;     :_id "2vr8sP-LTRWhSKOxyWOi_Q", :_version 1}
 ----
 


### PR DESCRIPTION
1. Redundant parens.
2. My main purpose is to correct the index name (people) to the actually used one (test4). But the output in my REPL turned out to be different to the texted one, not sure if it's because of a different version of ElasticSearch.
3. The symbol **doc** conflicts with **clojure.repl/doc** when executed in the REPL.
4. The alias of **clojurewerkz.elastisch.rest.document** here is **esd**. There's also an **esr/put**(**clojurewerkz.elastisch.rest/put**) but it takes totally different args and works differently.