### PR TITLE
Fix a require statement in 7.12 

### DIFF
--- a/07_webapps/7-12_templating-with-selmer.asciidoc
+++ b/07_webapps/7-12_templating-with-selmer.asciidoc
@@ -51,7 +51,7 @@ The template can then be rendered by calling the +selmer.parser/render-file+ fun
 
 [source, clojure]
 ----
-(require '[selmer.parser :refer [render-file]])
+(require '[selmer.parser :refer [render-file render]])
 
 (println
   (render-file "base.html"

--- a/07_webapps/7-12_templating-with-selmer.asciidoc
+++ b/07_webapps/7-12_templating-with-selmer.asciidoc
@@ -204,7 +204,7 @@ and display it on the page, we could write the following filter:footnote:[You'll
 [source, clojure]
 ----
 (require '[markdown.core :refer [md-to-html-string]]
-         '[selmer.filters/add-filter!])
+         '[selmer.filters :refer [add-filter!]])
 
 (add-filter! :markdown md-to-html-string)
 ----


### PR DESCRIPTION
I can't find anything about this kind of usage of "require": *(require '[selmer.filters/add-filter!])*, and this throws the FileNotFoundException. So I changed it to the :refer way.
By the way, add the function "render" to the refer list as it's used later.