### PR TITLE
Several fixes in 7.14

### DIFF
--- a/07_webapps/7-14_markdown.asciidoc
+++ b/07_webapps/7-14_markdown.asciidoc
@@ -134,7 +134,7 @@ Finally, we can provide a custom set of transformers to replace the built-in one
 
 [source,clojure]
 ----
-(markdown/md-to-html-string "#foo" :replacement-transformers [capitalize])
+(md/md-to-html-string "#foo" :replacement-transformers [capitalize])
 ----
 
 ==== See Also

--- a/07_webapps/7-14_markdown.asciidoc
+++ b/07_webapps/7-14_markdown.asciidoc
@@ -22,7 +22,8 @@ Use +markdown.core/md-to-html+ to read a Markdown document and generate a string
 
 [source,clojure]
 ----
-(require '[markdown.core :as md])
+(require '[markdown.core :as md]
+         '[clojure.java.io :refer [input-stream output-stream])
 
 (md/md-to-html "input.md" "output.html")
 

--- a/07_webapps/7-14_markdown.asciidoc
+++ b/07_webapps/7-14_markdown.asciidoc
@@ -91,7 +91,7 @@ When the +:heading-anchors+ key is set to +true+, an anchor will be generated fo
 [source,html]
 ----
 <h3>
-  <a name=\"heading\" class=\"anchor\" href=\"#foo&#95;bar&#95;baz></a>
+  <a name=\"heading\" class=\"anchor\" href=\"#foo&#95;bar&#95;baz\"></a>
   foo bar BAz
 </h3>
 ----


### PR DESCRIPTION
1. Require **clojure.java.io** for **input-stream** and **output-stream**.
2. Unmatched double quote mark.
3. **markdown.core** is aliased to **md** than **markdown** here.