### PR TITLE
Fix typo in namespace alias

### DIFF
--- a/04_local-io/4-13_parallelizing-file-processing-using-iota.asciidoc
+++ b/04_local-io/4-13_parallelizing-file-processing-using-iota.asciidoc
@@ -24,7 +24,7 @@ To count the words in a very large file, for example:
 
 [source,clojure]
 ----
-(require '[iota                  :as io]
+(require '[iota                  :as iota]
          '[clojure.core.reducers :as r]
          '[clojure.string        :as str])
 


### PR DESCRIPTION
The example uses `iota` instead of `io` as the namespace alias:

```clj
;; Main file processing
(defn keyword-count
  "Returns a map of the word counts"
  [filename]
  (->> (iota/seq filename)
       (r/filter identity)
       (r/map count-map)
       (r/fold add-maps)))
```