### PR TITLE
Fix example for inflection

### DIFF
--- a/01_primitive-data/1-11_inflecting-strings.asciidoc
+++ b/01_primitive-data/1-11_inflecting-strings.asciidoc
@@ -89,7 +89,7 @@ The library also has support for inflections like +camelize+,(((camel case)))(((
 [source,clojure]
 ----
 ;; Convert "snake_case" to "CamelCase"
-(inf/camelize "my_object")
+(inf/camel-case "my_object")
 ;; -> "MyObject"
 
 ;; Clean strings for usage as URL parameters


### PR DESCRIPTION
Hey guys,

I have tried to run the example from _1.11. Pluralizing Strings Based on a Quantity_ sub-section then stumbled upon a little issue :

```
user=> (inf/camelize "my_object")
"my_object"
CompilerException java.lang.RuntimeException: No such var: inf/camelize, compiling:(/tmp/form-init4525435471952857175.clj:1:1) 
```

We may have used the wrong function name here : `camelize`.
After checking https://github.com/r0man/inflections-clj/blob/master/src/inflections/core.cljc, it seems that we should have called `camel-case` instead.

I am providing this very very very small (so small indeed ^^) fix as my contribution to the improvement of this cookbook but also to thank you guys for this awesome book ;-)

thanks in advance for the review ...

